### PR TITLE
Fix build: Makefile case, missing NED, gate naming

### DIFF
--- a/omnetpp/simulations/Makefile
+++ b/omnetpp/simulations/Makefile
@@ -1,5 +1,5 @@
 TARGET = scm-simulations
-SRCS = src/main.cc src/SCMNode.cc src/SCMMessages.cc src/SCMFaultInjector.cc src/TwitchNetworkInitializer.cc
+SRCS = src/Main.cc src/SCMNode.cc src/SCMMessages.cc src/SCMFaultInjector.cc src/TopologyBuilders.cc src/TwitchNetworkInitializer.cc
 
 all: $(TARGET)
 

--- a/omnetpp/simulations/networks/SCMFaultInjector.ned
+++ b/omnetpp/simulations/networks/SCMFaultInjector.ned
@@ -1,0 +1,9 @@
+simple SCMFaultInjector {
+    parameters:
+        int faultType @default(0);           // 0=DISTANCE_TAMPER, 1=BETA_MODIFICATION, 2=PARENT_SWITCH
+        double faultProbability @default(0);  // Per-node probability of fault injection
+        double interval @unit(s) @default(10s);  // Time between injection rounds
+        double initialDelay @unit(s) @default(5s); // Delay before first injection
+
+        @display("i=block/cogwheel,red");
+}

--- a/omnetpp/simulations/networks/SCMNode.ned
+++ b/omnetpp/simulations/networks/SCMNode.ned
@@ -1,11 +1,11 @@
 simple SCMNode {
     parameters:
-        int numUsers;  // Number of users at this node
-        double linkCost @default(1.0);  // Transmission cost
-        
+        int id;
+        int numUsers;
+        double linkCost @default(1.0);
+
         @display("i=block/process");
-    
+
     gates:
-        input in[];  // Input gates
-        output out[]; // Output gates
+        inout port[];  // Bidirectional connections to neighbors
 }

--- a/omnetpp/simulations/networks/SimpleNetwork.ned
+++ b/omnetpp/simulations/networks/SimpleNetwork.ned
@@ -1,13 +1,17 @@
-simple SCMNode {
-    gates:
-        input in;
-        output out;
-}
+package overlay;
+
+import "SCMNode.ned";
 
 network SimpleNetwork {
     submodules:
-        node1: SCMNode;
-        node2: SCMNode;
+        node1: SCMNode {
+            id = 0;
+            numUsers = 1;
+        }
+        node2: SCMNode {
+            id = 1;
+            numUsers = 1;
+        }
     connections:
-        node1.out --> node2.in;
+        node1.port++ <--> { delay = 100ms; } <--> node2.port++;
 }

--- a/omnetpp/simulations/src/Main.cc
+++ b/omnetpp/simulations/src/Main.cc
@@ -1,9 +1,4 @@
+// Entry point placeholder.
+// OMNeT++ provides main() via the simulation library.
+// Module registrations are in their respective .cc files.
 #include <omnetpp.h>
-
-class SCMNode : public cSimpleModule {
-protected:
-    virtual void initialize() override {
-        EV << "Initializing " << getFullPath() << endl;
-    }
-};
-Define_Module(SCMNode);

--- a/omnetpp/simulations/src/SCMFaultInjector.cc
+++ b/omnetpp/simulations/src/SCMFaultInjector.cc
@@ -50,10 +50,11 @@ void SCMFaultInjector::injectFault()
                     break;
             }
             
-            // Notify neighbors about the fault
+            // Notify the node about the fault via direct message delivery
             SCMControlMessage *faultMsg = new SCMControlMessage("FaultNotify");
             faultMsg->setMsgType(SCMControlMessage::FAULT_NOTIFY);
-            send(faultMsg, "out", i);
+            faultMsg->setSenderId(-1);  // From fault injector
+            sendDirect(faultMsg, node, "port$i", 0);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix Makefile: `main.cc` -> `Main.cc` (case-sensitive), add missing `TopologyBuilders.cc`
- Create `SCMFaultInjector.ned` with params matching C++ code and ini config
- Standardize gates to `inout port[]` across `SCMNode.ned` and `SimpleNetwork.ned`
- Remove duplicate `SCMNode` class/registration from `Main.cc`
- Switch `SCMFaultInjector.cc` to `sendDirect()` to avoid unwired gate sends

Closes #1, closes #2, closes #3

## Test plan
- [ ] `make` in `omnetpp/simulations` finds all source files
- [ ] No NED import resolution errors at startup
- [ ] Gate names consistent across all `.ned` files and C++ code