### PR TITLE
Fix results pipeline: recursive discovery and OMNeT++ vec parser

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 set -e
 
-# Initialize results directory
-mkdir -p /workspace/results
+RESULTS_BASE=/workspace/results
+mkdir -p "$RESULTS_BASE"
 
-# Run experiments
+# Run experiments — each config writes to its own subdirectory
 cd /workspace/omnetpp/simulations
 for config in BaselineCBT FaultDistance BaselineER FaultBeta; do
-    ./scm-simulations -u Cmdenv -c $config -n ../networks \
-        --result-dir=/workspace/results/$config
+    echo "=== Running $config ==="
+    mkdir -p "$RESULTS_BASE/$config"
+    ./scm-simulations -u Cmdenv -c "$config" -n ../networks \
+        --result-dir="$RESULTS_BASE/$config"
 done
 
-# Create latest symlink
-ln -sfn $(date +%Y%m%d_%H%M%S) /workspace/results/latest
+# Create latest symlink pointing to the results root
+# (all scenario subdirectories live directly under $RESULTS_BASE)
+ln -sfn "$RESULTS_BASE" /workspace/results/latest
+
+echo "=== All simulations complete ==="

--- a/scripts/analysis/process_results.py
+++ b/scripts/analysis/process_results.py
@@ -1,34 +1,113 @@
 #!/usr/bin/env python3
+"""Parse OMNeT++ vector output files and produce per-scenario metrics."""
 import pandas as pd
 import numpy as np
 from pathlib import Path
+import re
+import sys
+
+
+def parse_vec_file(vec_path):
+    """Parse an OMNeT++ .vec file into a DataFrame.
+
+    OMNeT++ vector files contain:
+      - Header lines: version, run, attr, vector definitions
+      - Data lines: vectorId  eventNumber  simtime  value
+    """
+    vectors = {}   # vectorId -> (module, signalName)
+    rows = []
+
+    with open(vec_path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+
+            # Vector definition: vector <id> <module> <signal>:<type> <columns>
+            if line.startswith("vector "):
+                parts = line.split()
+                if len(parts) >= 4:
+                    vec_id = parts[1]
+                    module = parts[2]
+                    signal = parts[3].split(":")[0]  # strip :vector suffix
+                    vectors[vec_id] = (module, signal)
+                continue
+
+            # Skip other header lines
+            if line.startswith(("version", "run", "attr", "param", "itervar")):
+                continue
+
+            # Data line: vectorId  eventNumber  simtime  value
+            parts = line.split()
+            if len(parts) >= 4:
+                vec_id = parts[0]
+                if vec_id in vectors:
+                    module, signal = vectors[vec_id]
+                    try:
+                        rows.append({
+                            "module": module,
+                            "signal": signal,
+                            "time": float(parts[2]),
+                            "value": float(parts[3]),
+                        })
+                    except ValueError:
+                        continue
+
+    return pd.DataFrame(rows) if rows else pd.DataFrame(
+        columns=["module", "signal", "time", "value"]
+    )
+
 
 def analyze_results(result_dir):
-    # Load vector files
-    vec_files = list(Path(result_dir).glob("*.vec"))
-    
+    result_path = Path(result_dir)
+
+    # Search recursively for .vec files across per-scenario subdirectories
+    vec_files = list(result_path.rglob("*.vec"))
+
+    if not vec_files:
+        print(f"ERROR: No .vec files found under {result_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Found {len(vec_files)} .vec file(s)")
+
     dfs = []
     for vec in vec_files:
-        df = pd.read_csv(vec, sep="\t", comment="#",
-                        names=["time", "value", "attr"])
-        df["scenario"] = vec.stem.split("_")[0]
+        df = parse_vec_file(vec)
+        if df.empty:
+            print(f"  WARN: {vec.name} contained no data rows, skipping")
+            continue
+
+        # Derive scenario name from parent directory or filename
+        # run_experiments.sh puts files in results/<ConfigName>/
+        scenario = vec.parent.name if vec.parent != result_path else vec.stem.split("-")[0]
+        df["scenario"] = scenario
         dfs.append(df)
-    
-    combined = pd.concat(dfs)
-    
-    # Calculate metrics
-    metrics = combined.groupby("scenario").agg({
-        "value": ["mean", "std", "count"],
-        "time": ["max"]
-    })
-    
-    # Save analysis
-    metrics.to_csv(Path(result_dir) / "analysis.csv")
-    print(f"Saved analysis to {result_dir}/analysis.csv")
+        print(f"  Parsed {vec.name}: {len(df)} data points, scenario={scenario}")
+
+    if not dfs:
+        print("ERROR: All .vec files were empty", file=sys.stderr)
+        sys.exit(1)
+
+    combined = pd.concat(dfs, ignore_index=True)
+
+    # Calculate per-scenario metrics
+    metrics = combined.groupby("scenario").agg(
+        value_mean=("value", "mean"),
+        value_std=("value", "std"),
+        value_count=("value", "count"),
+        time_max=("time", "max"),
+    ).reset_index()
+
+    # Save with flat column names so downstream tools can read it trivially
+    out_path = result_path / "analysis.csv"
+    metrics.to_csv(out_path, index=False)
+    print(f"Saved analysis to {out_path}")
+    print(metrics.to_string(index=False))
+
 
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser()
-    parser.add_argument("result_dir", help="Directory with .vec files")
+    parser.add_argument("result_dir", help="Root results directory (searched recursively)")
     args = parser.parse_args()
     analyze_results(args.result_dir)

--- a/scripts/visualization/plot_metrics.py
+++ b/scripts/visualization/plot_metrics.py
@@ -1,34 +1,51 @@
 #!/usr/bin/env python3
+"""Generate summary bar charts from analysis.csv."""
 import pandas as pd
+import matplotlib
+matplotlib.use("Agg")  # Non-interactive backend (works headless / SSH)
 import matplotlib.pyplot as plt
 import seaborn as sns
 from pathlib import Path
+import sys
+
 
 def plot_metrics(result_dir):
-    df = pd.read_csv(Path(result_dir) / "analysis.csv")
-    
-    plt.figure(figsize=(12, 6))
-    
-    # Plot stabilization time
-    ax1 = plt.subplot(121)
-    sns.barplot(data=df, x="scenario", y=("time", "max"), ax=ax1)
+    csv_path = Path(result_dir) / "analysis.csv"
+
+    if not csv_path.exists():
+        print(f"ERROR: {csv_path} not found. Run process_results.py first.", file=sys.stderr)
+        sys.exit(1)
+
+    df = pd.read_csv(csv_path)
+
+    if df.empty:
+        print("ERROR: analysis.csv is empty", file=sys.stderr)
+        sys.exit(1)
+
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 6))
+
+    # Plot 1: Maximum stabilization time per scenario
+    sns.barplot(data=df, x="scenario", y="time_max", ax=ax1)
     ax1.set_title("Maximum Stabilization Time")
     ax1.set_ylabel("Seconds")
-    ax1.tick_params(axis='x', rotation=45)
-    
-    # Plot beta variance
-    ax2 = plt.subplot(122)
-    sns.barplot(data=df, x="scenario", y=("value", "std"), ax=ax2)
+    ax1.tick_params(axis="x", rotation=45)
+
+    # Plot 2: Beta value standard deviation per scenario
+    sns.barplot(data=df, x="scenario", y="value_std", ax=ax2)
     ax2.set_title("Beta Value Standard Deviation")
-    ax2.tick_params(axis='x', rotation=45)
-    
+    ax2.set_ylabel("Std Dev")
+    ax2.tick_params(axis="x", rotation=45)
+
     plt.tight_layout()
-    plt.savefig(Path(result_dir) / "metrics_plot.png")
-    print(f"Saved plot to {result_dir}/metrics_plot.png")
+
+    out_path = Path(result_dir) / "metrics_plot.png"
+    plt.savefig(out_path, dpi=150)
+    print(f"Saved plot to {out_path}")
+
 
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser()
-    parser.add_argument("result_dir", help="Directory with analysis.csv")
+    parser.add_argument("result_dir", help="Directory containing analysis.csv")
     args = parser.parse_args()
     plot_metrics(args.result_dir)


### PR DESCRIPTION
## Summary
- Rewrite `process_results.py`: recursive `.rglob("*.vec")` search across per-scenario subdirectories, proper OMNeT++ vector file format parser (header
lines + 4-column data), flat column names in output CSV, fail-fast errors
- Fix `plot_metrics.py`: match new flat column names (`time_max`, `value_std`), add `Agg` backend for headless/SSH operation
- Fix `entrypoint.sh`: broken `latest` symlink

Closes #5

## Test plan
- [ ] Script finds `.vec` files in nested subdirectories
- [ ] Parser handles OMNeT++ vector format (version/run/attr headers + data lines)
- [ ] `analysis.csv` has flat readable column names
- [ ] `metrics_plot.png` renders without display/GUI