### PR TITLE
ci: add smoke tests for compile-run-analyze pipeline (issue #7)

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -1,0 +1,67 @@
+name: ci-smoke
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  preprocess-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run preprocessing tests
+        run: uv run python -m unittest tests/test_preprocess.py -v
+
+  docker-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build Docker image
+        run: docker build -f docker/Dockerfile -t scm-overlay-omnet:ci .
+
+      - name: Run quick pipeline in container
+        run: |
+          mkdir -p "$RUNNER_TEMP/scm-results"
+          docker run --rm \
+            -v "$RUNNER_TEMP/scm-results:/tmp/results" \
+            -e RESULT_DIR=/tmp/results \
+            -e SCM_RANDOM_SEED=1337 \
+            scm-overlay-omnet:ci \
+            /bin/bash -lc "cd /workspace/omnetpp/simulations && ./scm-simulations -u Cmdenv -c BaselineCBT -n networks --result-dir=/tmp/results/BaselineCBT-smoke"
+
+      - name: Generate analysis+plot smoke artifact in container
+        run: |
+          docker run --rm \
+            -v "$RUNNER_TEMP/scm-results:/tmp/results" \
+            scm-overlay-omnet:ci \
+            /workspace/.venv/bin/python \
+            /workspace/scripts/analysis/build_fig2_outputs.py /tmp/results/fig2-smoke --num-nodes 255 --max-depth 8 --seed 1337
+
+      - name: Validate quick output artifacts
+        run: |
+          docker run --rm \
+            -v "$RUNNER_TEMP/scm-results:/tmp/results" \
+            scm-overlay-omnet:ci \
+            /workspace/.venv/bin/python \
+            /workspace/scripts/analysis/validate_outputs.py /tmp/results/fig2-smoke --require-columns topology,depth,avg_beta_pct_increase,avg_payment_pct_increase,user_fraction_receiving_service --require-non-empty

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,47 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestPreprocessScripts(unittest.TestCase):
+    def test_generate_cbt_edges(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "cbt_edges.txt"
+            subprocess.run(
+                ["uv", "run", "python", "scripts/preprocess/generate_cbt.py", "--depth", "2", "--output", str(out)],
+                check=True,
+            )
+            lines = out.read_text(encoding="utf-8").strip().splitlines()
+            self.assertTrue(lines[0].startswith("# Complete Binary Tree"))
+            # depth=2 => 7 nodes => 6 edges
+            self.assertEqual(len(lines), 7)
+            self.assertIn("0 1", lines)
+            self.assertIn("0 2", lines)
+
+    def test_generate_er_seeded_deterministic(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out1 = Path(tmp) / "er1.txt"
+            out2 = Path(tmp) / "er2.txt"
+            cmd = [
+                "uv",
+                "run",
+                "python",
+                "scripts/preprocess/generate_er.py",
+                "--nodes",
+                "12",
+                "--prob",
+                "0.25",
+                "--seed",
+                "1337",
+            ]
+            subprocess.run([*cmd, "--output", str(out1)], check=True)
+            subprocess.run([*cmd, "--output", str(out2)], check=True)
+            self.assertEqual(
+                out1.read_text(encoding="utf-8"),
+                out2.read_text(encoding="utf-8"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds CI smoke checks for compile/run/analyze flow and preprocessing tests.

## What changed
- Added `.github/workflows/ci-smoke.yml`
  - `preprocess-tests` job: runs deterministic script tests for CBT/ER generation
  - `docker-smoke` job:
    - builds Docker image
    - runs headless BaselineCBT simulation smoke
    - generates analysis+plot artifact via figure script
    - validates output contract (`analysis.csv` + `metrics_plot.png`)
- Added `tests/test_preprocess.py` with:
  - CBT edge generation shape check
  - ER seeded determinism check

## Validation performed locally
- `uv run python -m unittest tests/test_preprocess.py -v`
- Local container smoke equivalent:
  - headless simulation run
  - fig2-smoke artifact generation
  - contract validation via `validate_outputs.py`

Closes #7
