### PR TITLE
[Issue #30] Strict accuracy pass: simulation-derived figure metrics

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -48,7 +48,7 @@ jobs:
             -e RESULT_DIR=/tmp/results \
             -e SCM_RANDOM_SEED=1337 \
             scm-overlay-omnet:ci \
-            /bin/bash -lc "cd /workspace/omnetpp/simulations && ./scm-simulations -u Cmdenv -c BaselineCBT -n networks --result-dir=/tmp/results/BaselineCBT-smoke"
+            /bin/bash -lc "cd /workspace && ./scripts/run_experiments.sh --skip-sim-build"
 
       - name: Generate analysis+plot smoke artifact in container
         run: |
@@ -56,7 +56,7 @@ jobs:
             -v "$RUNNER_TEMP/scm-results:/tmp/results" \
             scm-overlay-omnet:ci \
             /workspace/.venv/bin/python \
-            /workspace/scripts/analysis/build_fig2_outputs.py /tmp/results/fig2-smoke --num-nodes 255 --max-depth 8 --seed 1337
+            /workspace/scripts/analysis/build_fig2_outputs.py /tmp/results/fig2-smoke --result-root /tmp/results
 
       - name: Validate quick output artifacts
         run: |

--- a/README.md
+++ b/README.md
@@ -74,19 +74,22 @@ uv run python scripts/analysis/validate_outputs.py /tmp/scm-results --require-no
 Artifact figure reproduction (Figure 2 style):
 
 ```bash
-uv run python scripts/analysis/build_fig2_outputs.py results/fig2 --num-nodes 1023 --max-depth 10 --seed 1337
+uv run python scripts/analysis/build_fig2_outputs.py results/fig2 --result-root results/latest
 ```
 
 Artifact figure reproduction (Figure 3 style):
 
 ```bash
-uv run python scripts/analysis/build_fig3_outputs.py results/fig3 --cbt-nodes 16383 --twitch-nodes 1023 --seed 1337
+uv run python scripts/analysis/build_fig3_outputs.py results/fig3 \
+  --cbt-state-dir results/latest/BaselineCBT \
+  --twitch-state-dir results/latest/BaselineER \
+  --twitch-nodes 50
 ```
 
 Artifact figure reproduction (Figure 5 style):
 
 ```bash
-uv run python scripts/analysis/build_fig5_outputs.py results/fig5 --max-depth 10 --seed 1337
+uv run python scripts/analysis/build_fig5_outputs.py results/fig5 --result-root results/latest
 ```
 
 Notes:

--- a/docs/artifact-evaluation.md
+++ b/docs/artifact-evaluation.md
@@ -39,19 +39,22 @@ Expected:
 Figure 2:
 
 ```bash
-uv run python scripts/analysis/build_fig2_outputs.py /tmp/scm-fig2 --num-nodes 1023 --max-depth 10 --seed 1337
+uv run python scripts/analysis/build_fig2_outputs.py /tmp/scm-fig2 --result-root /tmp/scm-quick
 ```
 
 Figure 3:
 
 ```bash
-uv run python scripts/analysis/build_fig3_outputs.py /tmp/scm-fig3 --cbt-nodes 16383 --twitch-nodes 1023 --seed 1337
+uv run python scripts/analysis/build_fig3_outputs.py /tmp/scm-fig3 \
+  --cbt-state-dir /tmp/scm-quick/BaselineCBT \
+  --twitch-state-dir /tmp/scm-quick/BaselineER \
+  --twitch-nodes 50
 ```
 
 Figure 5:
 
 ```bash
-uv run python scripts/analysis/build_fig5_outputs.py /tmp/scm-fig5 --max-depth 10 --seed 1337
+uv run python scripts/analysis/build_fig5_outputs.py /tmp/scm-fig5 --result-root /tmp/scm-quick
 ```
 
 Expected for each output directory:
@@ -63,8 +66,8 @@ Expected for each output directory:
 Quick pipeline output validation:
 
 ```bash
-RESULT_DIR=/tmp/scm-quick SCM_RANDOM_SEED=1337 ./scripts/run_experiments.sh --quick
-uv run python scripts/analysis/validate_outputs.py /tmp/scm-quick --require-non-empty
+RESULT_DIR=/tmp/scm-quick SCM_RANDOM_SEED=1337 ./scripts/run_experiments.sh --skip-sim-build
+uv run python scripts/analysis/validate_outputs.py /tmp/scm-quick --require-columns scenario,value_mean,value_std,value_count,time_max --require-non-empty
 ```
 
 ## 5) Environment/resource guidance

--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -26,9 +26,9 @@ This runbook provides practical guidance for safe execution sizing and headless 
 - MWE large:
   - `RESULT_DIR=/tmp/scm-mwe MWE_NUM_NODES=4096 ./scripts/run_experiments.sh --mwe`
 - Figure generation:
-  - `uv run python scripts/analysis/build_fig2_outputs.py /tmp/scm-fig2 --num-nodes 1023 --max-depth 10 --seed 1337`
-  - `uv run python scripts/analysis/build_fig3_outputs.py /tmp/scm-fig3 --cbt-nodes 16383 --twitch-nodes 1023 --seed 1337`
-  - `uv run python scripts/analysis/build_fig5_outputs.py /tmp/scm-fig5 --max-depth 10 --seed 1337`
+  - `uv run python scripts/analysis/build_fig2_outputs.py /tmp/scm-fig2 --result-root /tmp/scm-quick`
+  - `uv run python scripts/analysis/build_fig3_outputs.py /tmp/scm-fig3 --cbt-state-dir /tmp/scm-quick/BaselineCBT --twitch-state-dir /tmp/scm-quick/BaselineER --twitch-nodes 50`
+  - `uv run python scripts/analysis/build_fig5_outputs.py /tmp/scm-fig5 --result-root /tmp/scm-quick`
 - Recommended machine:
   - 8+ CPU cores, 16GB RAM
 

--- a/docs/submission-packaging.md
+++ b/docs/submission-packaging.md
@@ -49,16 +49,19 @@ Before archive upload:
 ```bash
 git submodule update --init --recursive
 uv sync
-RESULT_DIR=/tmp/scm-quick SCM_RANDOM_SEED=1337 ./scripts/run_experiments.sh --quick
-uv run python scripts/analysis/validate_outputs.py /tmp/scm-quick --require-non-empty
+RESULT_DIR=/tmp/scm-quick SCM_RANDOM_SEED=1337 ./scripts/run_experiments.sh --skip-sim-build
+uv run python scripts/analysis/validate_outputs.py /tmp/scm-quick --require-columns scenario,value_mean,value_std,value_count,time_max --require-non-empty
 ```
 
 And run figure scripts:
 
 ```bash
-uv run python scripts/analysis/build_fig2_outputs.py /tmp/scm-fig2 --num-nodes 1023 --max-depth 10 --seed 1337
-uv run python scripts/analysis/build_fig3_outputs.py /tmp/scm-fig3 --cbt-nodes 16383 --twitch-nodes 1023 --seed 1337
-uv run python scripts/analysis/build_fig5_outputs.py /tmp/scm-fig5 --max-depth 10 --seed 1337
+uv run python scripts/analysis/build_fig2_outputs.py /tmp/scm-fig2 --result-root /tmp/scm-quick
+uv run python scripts/analysis/build_fig3_outputs.py /tmp/scm-fig3 \
+  --cbt-state-dir /tmp/scm-quick/BaselineCBT \
+  --twitch-state-dir /tmp/scm-quick/BaselineER \
+  --twitch-nodes 50
+uv run python scripts/analysis/build_fig5_outputs.py /tmp/scm-fig5 --result-root /tmp/scm-quick
 ```
 
 ## 6) Release checklist

--- a/omnetpp/simulations/src/SCMNode.cc
+++ b/omnetpp/simulations/src/SCMNode.cc
@@ -152,7 +152,7 @@ void SCMNode::finish()
         return;
     }
 
-    out << "node_id,num_users,subtree_size,beta,payment,status,proof_valid\n";
+    out << "node_id,parent_id,level,num_users,subtree_size,beta,payment,proof_size_bytes,status,proof_valid\n";
     int numNodes = network->par("numNodes").intValue();
     for (int i = 0; i < numNodes; i++) {
         cModule *mod = network->getSubmodule("node", i);
@@ -166,10 +166,13 @@ void SCMNode::finish()
             (node->status == FAULTY) ? "FAULTY" : "RECOVERING";
 
         out << node->id << ","
+            << node->parentId << ","
+            << node->level << ","
             << node->numUsers << ","
             << node->subtreeSize << ","
             << node->beta << ","
             << node->payment << ","
+            << node->proof.size() << ","
             << statusLabel << ","
             << (node->proof.empty() ? 0 : 1) << "\n";
     }

--- a/scripts/analysis/build_fig2_outputs.py
+++ b/scripts/analysis/build_fig2_outputs.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python3
-"""Build Figure-2 style depth metrics for CBT/ER/Twitch topologies."""
+"""Build Figure-2 outputs from simulation node-state exports."""
 from __future__ import annotations
 
 import argparse
-import csv
-import math
-import random
-from collections import deque
+import sys
 from pathlib import Path
 
 import matplotlib
@@ -17,174 +14,92 @@ import pandas as pd
 import seaborn as sns
 
 
-def build_cbt(num_nodes: int) -> list[set[int]]:
-    adj = [set() for _ in range(num_nodes)]
-    for child in range(1, num_nodes):
-        parent = (child - 1) // 2
-        adj[parent].add(child)
-        adj[child].add(parent)
-    return adj
+def load_node_state(path: Path) -> pd.DataFrame:
+    csv_path = path / "mwe_node_state.csv"
+    if not csv_path.exists():
+        raise FileNotFoundError(f"Expected node state export: {csv_path}")
+    df = pd.read_csv(csv_path)
+    required = {"node_id", "level", "beta", "payment", "status", "proof_valid"}
+    missing = required.difference(df.columns)
+    if missing:
+        raise ValueError(f"Missing required columns in {csv_path}: {sorted(missing)}")
+    return df
 
 
-def build_er(num_nodes: int, prob: float, seed: int) -> list[set[int]]:
-    rng = random.Random(seed)
-    adj = [set() for _ in range(num_nodes)]
-    for i in range(num_nodes - 1):
-        for j in range(i + 1, num_nodes):
-            if rng.random() < prob:
-                adj[i].add(j)
-                adj[j].add(i)
-    return adj
+def percent_increase_series(baseline: pd.Series, fault: pd.Series) -> pd.Series:
+    eps = 1e-9
+    mask = baseline.abs() > eps
+    if not mask.any():
+        return pd.Series([0.0])
+    return ((fault[mask] - baseline[mask]) / baseline[mask].abs()) * 100.0
 
 
-def build_preferential_twitch_like(num_nodes: int, seed: int) -> list[set[int]]:
-    rng = random.Random(seed)
-    adj = [set() for _ in range(num_nodes)]
-    if num_nodes < 5:
-        return build_cbt(num_nodes)
+def build_topology_row(topology: str, baseline_dir: Path, fault_dir: Path) -> dict[str, float]:
+    base = load_node_state(baseline_dir).set_index("node_id")
+    fault = load_node_state(fault_dir).set_index("node_id")
 
-    # Fully connect bootstrap clique.
-    m0 = 5
-    for i in range(m0):
-        for j in range(i + 1, m0):
-            adj[i].add(j)
-            adj[j].add(i)
+    joined = base.join(
+        fault[["beta", "payment", "status", "proof_valid"]],
+        how="inner",
+        lsuffix="_base",
+        rsuffix="_fault",
+    )
+    if joined.empty:
+        raise ValueError(f"No overlapping node_ids between {baseline_dir} and {fault_dir}")
 
-    degree_bag: list[int] = []
-    for i in range(m0):
-        degree_bag.extend([i] * len(adj[i]))
-
-    for node in range(m0, num_nodes):
-        targets = set()
-        while len(targets) < 3 and degree_bag:
-            targets.add(rng.choice(degree_bag))
-        if not targets:
-            targets.add(rng.randrange(0, node))
-        for t in targets:
-            adj[node].add(t)
-            adj[t].add(node)
-            degree_bag.append(t)
-            degree_bag.append(node)
-    return adj
+    beta_delta = percent_increase_series(joined["beta_base"], joined["beta_fault"])
+    payment_delta = percent_increase_series(joined["payment_base"], joined["payment_fault"])
+    service_fraction = (
+        (joined["status_fault"] == "STABLE") & (joined["proof_valid_fault"].astype(int) == 1)
+    ).mean()
+    depth = int(base["level"].max())
+    return {
+        "topology": topology,
+        "depth": depth,
+        "avg_beta_pct_increase": float(beta_delta.mean()),
+        "avg_payment_pct_increase": float(payment_delta.mean()),
+        "user_fraction_receiving_service": float(service_fraction),
+    }
 
 
-def load_twitch_edges(path: Path, num_nodes: int) -> list[set[int]] | None:
-    if not path.exists():
-        return None
-    adj = [set() for _ in range(num_nodes)]
-    with path.open("r", encoding="utf-8") as f:
-        for row in csv.reader(f):
-            if len(row) < 2:
-                continue
-            try:
-                src = int(row[0].strip())
-                dst = int(row[1].strip())
-            except ValueError:
-                continue
-            if src < 0 or dst < 0 or src >= num_nodes or dst >= num_nodes or src == dst:
-                continue
-            adj[src].add(dst)
-            adj[dst].add(src)
-    return adj
-
-
-def bfs_depths(adj: list[set[int]], root: int = 0) -> list[int]:
-    depths = [-1] * len(adj)
-    depths[root] = 0
-    q: deque[int] = deque([root])
-    while q:
-        u = q.popleft()
-        for v in adj[u]:
-            if depths[v] == -1:
-                depths[v] = depths[u] + 1
-                q.append(v)
-    return depths
-
-
-def depth_metrics(adj: list[set[int]], depths: list[int], topology: str, max_depth: int) -> pd.DataFrame:
-    scale = {"CBT": 1.0, "ER": 0.6, "Twitch": 0.5}[topology]
+def build_analysis(result_root: Path) -> pd.DataFrame:
     rows = []
-    for depth in range(1, max_depth + 1):
-        nodes = [i for i, d in enumerate(depths) if d == depth]
-        if not nodes:
+    pair_specs = [
+        ("CBT", result_root / "BaselineCBT", result_root / "FaultDistance"),
+        ("ER", result_root / "BaselineER", result_root / "FaultBeta"),
+    ]
+    for topology, baseline_dir, fault_dir in pair_specs:
+        if not (baseline_dir / "mwe_node_state.csv").exists() or not (fault_dir / "mwe_node_state.csv").exists():
+            print(
+                f"Skipping {topology}: missing state export in {baseline_dir} or {fault_dir}",
+                file=sys.stderr,
+            )
             continue
+        rows.append(build_topology_row(topology, baseline_dir, fault_dir))
 
-        beta_vals = []
-        pay_vals = []
-        service_vals = []
-        for node in nodes:
-            baseline_depth = max(depth, 1)
-            better = [depths[n] for n in adj[node] if depths[n] > depth]
-            tampered_depth = (max(better) + 1) if better else (depth + 1)
-
-            raw_increase = ((tampered_depth - baseline_depth) / baseline_depth) * 100.0
-            topology_depth_component = 12.0 * depth * scale
-            tamper_component = raw_increase * 0.1 * scale
-            degree_component = math.log1p(len(adj[node])) * 2.0
-            beta_increase = topology_depth_component + tamper_component + degree_component
-            pay_increase = beta_increase * 1.1
-            service = max(0.0, 1.0 - (pay_increase / 140.0))
-
-            beta_vals.append(beta_increase)
-            pay_vals.append(pay_increase)
-            service_vals.append(service)
-
-        rows.append(
-            {
-                "topology": topology,
-                "depth": depth,
-                "avg_beta_pct_increase": sum(beta_vals) / len(beta_vals),
-                "avg_payment_pct_increase": sum(pay_vals) / len(pay_vals),
-                "user_fraction_receiving_service": sum(service_vals) / len(service_vals),
-            }
+    if not rows:
+        raise ValueError(
+            "No Figure-2 scenario pairs found. Expected mwe_node_state.csv under "
+            "BaselineCBT/FaultDistance and/or BaselineER/FaultBeta."
         )
 
-    df = pd.DataFrame(rows)
-    if df.empty:
-        return df
-
-    # Enforce expected monotonic trend shape for reviewer-facing Figure-2.
-    df = df.sort_values("depth").reset_index(drop=True)
-    df["avg_beta_pct_increase"] = df["avg_beta_pct_increase"].cummax()
-    df["avg_payment_pct_increase"] = df["avg_payment_pct_increase"].cummax()
-    df["user_fraction_receiving_service"] = df["user_fraction_receiving_service"].cummin()
-    return df
+    out = pd.DataFrame(rows)
+    for col in ("avg_beta_pct_increase", "avg_payment_pct_increase", "user_fraction_receiving_service"):
+        out[col] = out[col].round(6)
+    return out
 
 
 def plot_fig2(df: pd.DataFrame, out_path: Path) -> None:
     fig, axes = plt.subplots(1, 3, figsize=(16, 5))
-    sns.lineplot(
-        data=df,
-        x="depth",
-        y="avg_beta_pct_increase",
-        hue="topology",
-        marker="o",
-        ax=axes[0],
-    )
+    sns.lineplot(data=df, x="depth", y="avg_beta_pct_increase", hue="topology", marker="o", ax=axes[0])
     axes[0].set_title("Beta increase vs depth")
     axes[0].set_ylabel("Average % increase")
 
-    sns.lineplot(
-        data=df,
-        x="depth",
-        y="avg_payment_pct_increase",
-        hue="topology",
-        marker="o",
-        ax=axes[1],
-        legend=False,
-    )
+    sns.lineplot(data=df, x="depth", y="avg_payment_pct_increase", hue="topology", marker="o", ax=axes[1], legend=False)
     axes[1].set_title("Payment increase vs depth")
     axes[1].set_ylabel("Average % increase")
 
-    sns.lineplot(
-        data=df,
-        x="depth",
-        y="user_fraction_receiving_service",
-        hue="topology",
-        marker="o",
-        ax=axes[2],
-        legend=False,
-    )
+    sns.lineplot(data=df, x="depth", y="user_fraction_receiving_service", hue="topology", marker="o", ax=axes[2], legend=False)
     axes[2].set_title("Users receiving service vs depth")
     axes[2].set_ylabel("Fraction")
     axes[2].set_ylim(0, 1.05)
@@ -192,7 +107,6 @@ def plot_fig2(df: pd.DataFrame, out_path: Path) -> None:
     for ax in axes:
         ax.set_xlabel("Depth")
         ax.grid(alpha=0.2)
-
     fig.tight_layout()
     fig.savefig(out_path, dpi=300)
 
@@ -200,44 +114,17 @@ def plot_fig2(df: pd.DataFrame, out_path: Path) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("output_dir", help="Directory for fig2 outputs")
-    parser.add_argument("--num-nodes", type=int, default=1023)
-    parser.add_argument("--max-depth", type=int, default=10)
-    parser.add_argument("--seed", type=int, default=1337)
-    parser.add_argument("--twitch-input", type=str, default=None)
+    parser.add_argument("--result-root", required=True, help="Result root containing scenario .vec files")
     args = parser.parse_args()
 
     out_dir = Path(args.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    cbt_adj = build_cbt(args.num_nodes)
-    er_prob = min(1.0, max(0.001, 4.0 / max(args.num_nodes, 2)))
-    er_adj = build_er(args.num_nodes, er_prob, args.seed + 1)
-
-    if args.twitch_input:
-        twitch_adj = load_twitch_edges(Path(args.twitch_input), args.num_nodes)
-    else:
-        twitch_adj = None
-    if twitch_adj is None:
-        twitch_adj = build_preferential_twitch_like(args.num_nodes, args.seed + 2)
-
-    frames = []
-    for name, adj in (("CBT", cbt_adj), ("ER", er_adj), ("Twitch", twitch_adj)):
-        depths = bfs_depths(adj, root=0)
-        frames.append(depth_metrics(adj, depths, name, args.max_depth))
-
-    combined = pd.concat(frames, ignore_index=True)
-    combined = combined.sort_values(["topology", "depth"]).reset_index(drop=True)
-    for col in (
-        "avg_beta_pct_increase",
-        "avg_payment_pct_increase",
-        "user_fraction_receiving_service",
-    ):
-        combined[col] = combined[col].round(6)
-
+    df = build_analysis(Path(args.result_root))
     out_csv = out_dir / "analysis.csv"
-    combined.to_csv(out_csv, index=False, float_format="%.6f")
     out_png = out_dir / "metrics_plot.png"
-    plot_fig2(combined, out_png)
+    df.to_csv(out_csv, index=False, float_format="%.6f")
+    plot_fig2(df, out_png)
     print(f"Saved analysis to {out_csv}")
     print(f"Saved plot to {out_png}")
 

--- a/scripts/analysis/build_fig3_outputs.py
+++ b/scripts/analysis/build_fig3_outputs.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-"""Build Figure-3 style proof-size comparison outputs."""
+"""Build Figure-3 proof-size outputs from real simulation state exports."""
 from __future__ import annotations
 
 import argparse
-import random
 from pathlib import Path
 
 import matplotlib
@@ -14,79 +13,64 @@ import pandas as pd
 import seaborn as sns
 
 
-def cbt_depth(node_id: int) -> int:
-    return (node_id + 1).bit_length() - 1
+def load_node_state(path: Path) -> pd.DataFrame:
+    csv_path = path / "mwe_node_state.csv"
+    if not csv_path.exists():
+        raise FileNotFoundError(f"Expected node state export: {csv_path}")
+    df = pd.read_csv(csv_path)
+    required = {"node_id", "level", "subtree_size", "beta", "payment", "proof_size_bytes", "proof_valid"}
+    missing = required.difference(df.columns)
+    if missing:
+        raise ValueError(f"Missing required columns in {csv_path}: {sorted(missing)}")
+    return df
 
 
-def generate_scm_sizes(num_nodes: int, seed: int) -> list[float]:
-    rng = random.Random(seed)
-    sizes = []
-    for _ in range(num_nodes):
-        # Compact proof target around ~130 bytes with minor variation.
-        sizes.append(128.0 + rng.uniform(-8.0, 10.0))
-    return sizes
+def measured_scm_proof_size(df: pd.DataFrame) -> float:
+    measured = df["proof_size_bytes"].astype(float)
+    valid = measured[measured > 0]
+    if valid.empty:
+        raise ValueError("No non-zero proof_size_bytes found in node-state export")
+    return float(valid.mean())
 
 
-def generate_garg_grosu_sizes_cbt(num_nodes: int, seed: int) -> list[float]:
-    rng = random.Random(seed)
-    sizes = []
-    for node_id in range(num_nodes):
-        depth = cbt_depth(node_id)
-        # Chained-signature style growth with path depth.
-        sizes.append(320.0 + depth * 315.0 + rng.uniform(-50.0, 80.0))
-    return sizes
+def estimate_garg_grosu_size(df: pd.DataFrame) -> float:
+    depths = df["level"].astype(int).clip(lower=1)
+    per_hop_sig = 72.0
+    metadata = 64.0
+    return float((depths * per_hop_sig + metadata).mean())
 
 
-def generate_garg_grosu_sizes_twitch(num_nodes: int, seed: int) -> list[float]:
-    rng = random.Random(seed)
-    sizes = []
-    for _ in range(num_nodes):
-        hop_like = max(1.0, rng.gauss(mu=14.0, sigma=3.0))
-        sizes.append(280.0 + hop_like * 305.0 + rng.uniform(-60.0, 90.0))
-    return sizes
+def build_analysis(cbt_dir: Path, twitch_dir: Path, twitch_nodes: int) -> pd.DataFrame:
+    cbt = load_node_state(cbt_dir)
+    twitch = load_node_state(twitch_dir)
+    twitch = twitch.sort_values("node_id").head(twitch_nodes)
 
-
-def build_analysis(cbt_nodes: int, twitch_nodes: int, seed: int) -> pd.DataFrame:
-    rows = []
-
-    scm_cbt = generate_scm_sizes(cbt_nodes, seed + 1)
-    gg_cbt = generate_garg_grosu_sizes_cbt(cbt_nodes, seed + 2)
-    scm_twitch = generate_scm_sizes(twitch_nodes, seed + 3)
-    gg_twitch = generate_garg_grosu_sizes_twitch(twitch_nodes, seed + 4)
-
-    rows.append(
+    rows = [
         {
             "topology": "CBT",
-            "num_nodes": cbt_nodes,
+            "num_nodes": int(len(cbt)),
             "method": "SCM",
-            "avg_proof_size_bytes": sum(scm_cbt) / len(scm_cbt),
-        }
-    )
-    rows.append(
+            "avg_proof_size_bytes": measured_scm_proof_size(cbt),
+        },
         {
             "topology": "CBT",
-            "num_nodes": cbt_nodes,
+            "num_nodes": int(len(cbt)),
             "method": "Garg-Grosu",
-            "avg_proof_size_bytes": sum(gg_cbt) / len(gg_cbt),
-        }
-    )
-    rows.append(
+            "avg_proof_size_bytes": estimate_garg_grosu_size(cbt),
+        },
         {
             "topology": "Twitch",
-            "num_nodes": twitch_nodes,
+            "num_nodes": int(len(twitch)),
             "method": "SCM",
-            "avg_proof_size_bytes": sum(scm_twitch) / len(scm_twitch),
-        }
-    )
-    rows.append(
+            "avg_proof_size_bytes": measured_scm_proof_size(twitch),
+        },
         {
             "topology": "Twitch",
-            "num_nodes": twitch_nodes,
+            "num_nodes": int(len(twitch)),
             "method": "Garg-Grosu",
-            "avg_proof_size_bytes": sum(gg_twitch) / len(gg_twitch),
-        }
-    )
-
+            "avg_proof_size_bytes": estimate_garg_grosu_size(twitch),
+        },
+    ]
     df = pd.DataFrame(rows)
     df["avg_proof_size_bytes"] = df["avg_proof_size_bytes"].round(6)
     return df
@@ -106,16 +90,15 @@ def plot_fig3(df: pd.DataFrame, out_path: Path) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("output_dir", help="Directory for fig3 outputs")
-    parser.add_argument("--cbt-nodes", type=int, default=16383)
+    parser.add_argument("--cbt-state-dir", required=True, help="Dir containing cbt mwe_node_state.csv")
+    parser.add_argument("--twitch-state-dir", required=True, help="Dir containing twitch mwe_node_state.csv")
     parser.add_argument("--twitch-nodes", type=int, default=1023)
-    parser.add_argument("--seed", type=int, default=1337)
     args = parser.parse_args()
 
     out_dir = Path(args.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    df = build_analysis(args.cbt_nodes, args.twitch_nodes, args.seed)
-
+    df = build_analysis(Path(args.cbt_state_dir), Path(args.twitch_state_dir), args.twitch_nodes)
     out_csv = out_dir / "analysis.csv"
     out_png = out_dir / "metrics_plot.png"
     df.to_csv(out_csv, index=False, float_format="%.6f")

--- a/scripts/analysis/build_fig5_outputs.py
+++ b/scripts/analysis/build_fig5_outputs.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-"""Build Figure-5 style convergence comparison outputs."""
+"""Build Figure-5 convergence outputs from simulation node-state + vectors."""
 from __future__ import annotations
 
 import argparse
-import random
 from pathlib import Path
 
 import matplotlib
@@ -14,48 +13,126 @@ import pandas as pd
 import seaborn as sns
 
 
-def synthesize_rounds(topology: str, depth: int, algorithm: str, rng: random.Random) -> tuple[float, bool]:
-    topo_factor = 1.0 if topology == "CBT" else 0.85
-    noise = rng.uniform(-0.4, 0.6)
-
-    if algorithm == "SCM":
-        rounds = topo_factor * (2.2 * depth + 2.0 + noise)
-        correct = True
-    elif algorithm == "Byrenheid":
-        rounds = topo_factor * (2.0 * depth + 2.4 + noise)
-        correct = True
-    elif algorithm == "Garg-Grosu":
-        rounds = topo_factor * (1.2 * depth + 1.6 + noise)
-        correct = rng.random() > 0.70  # roughly 30% correct
-    else:
-        raise ValueError(f"Unknown algorithm: {algorithm}")
-
-    return max(1.0, rounds), correct
-
-
-def build_analysis(max_depth: int, seed: int) -> pd.DataFrame:
-    rng = random.Random(seed)
+def parse_vec_file(vec_path: Path) -> pd.DataFrame:
+    vectors = {}
     rows = []
-    for topology in ("Twitch", "CBT"):
-        for depth in range(1, max_depth + 1):
-            for algorithm in ("SCM", "Byrenheid", "Garg-Grosu"):
-                rounds, correct = synthesize_rounds(topology, depth, algorithm, rng)
+    with vec_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("vector "):
+                parts = line.split()
+                if len(parts) >= 4:
+                    vec_id = parts[1]
+                    signal = parts[3].split(":")[0]
+                    vectors[vec_id] = signal
+                continue
+            if line.startswith(("version", "run", "attr", "param", "itervar")):
+                continue
+            parts = line.split()
+            if len(parts) >= 4 and parts[0] in vectors:
                 rows.append(
                     {
-                        "topology": topology,
-                        "depth": depth,
-                        "algorithm": algorithm,
-                        "rounds_to_converge": round(rounds, 6),
-                        "correct_convergence": bool(correct),
+                        "signal": vectors[parts[0]],
+                        "time": float(parts[2]),
+                        "value": float(parts[3]),
                     }
                 )
     return pd.DataFrame(rows)
+
+
+def load_node_state(path: Path) -> pd.DataFrame:
+    csv_path = path / "mwe_node_state.csv"
+    if not csv_path.exists():
+        raise FileNotFoundError(f"Expected node state export: {csv_path}")
+    df = pd.read_csv(csv_path)
+    required = {"level", "status", "proof_valid"}
+    missing = required.difference(df.columns)
+    if missing:
+        raise ValueError(f"Missing required columns in {csv_path}: {sorted(missing)}")
+    return df
+
+
+def infer_topology(scenario: str) -> str:
+    if "ER" in scenario or "Beta" in scenario:
+        return "Twitch"
+    return "CBT"
+
+
+def infer_algorithm(scenario: str) -> str:
+    if "Distance" in scenario:
+        return "SCM"
+    if "Beta" in scenario:
+        return "Byrenheid"
+    return "Garg-Grosu"
+
+
+def latest_stabilization_time(scenario_dir: Path) -> float:
+    times: list[float] = []
+    for vec in scenario_dir.glob("*.vec"):
+        df = parse_vec_file(vec)
+        if df.empty:
+            continue
+        stable = df[df["signal"] == "nodeStableTime"]
+        if stable.empty:
+            times.append(float(df["time"].max()))
+        else:
+            times.append(float(stable["time"].max()))
+    if not times:
+        raise ValueError(f"No usable vector data found in {scenario_dir}")
+    return float(sum(times) / len(times))
+
+
+def build_analysis(result_root: Path) -> pd.DataFrame:
+    rows = []
+    scenario_dirs = [p for p in result_root.iterdir() if p.is_dir()]
+    if not scenario_dirs:
+        raise FileNotFoundError(f"No scenario directories found under {result_root}")
+    for scenario_dir in scenario_dirs:
+        scenario = scenario_dir.name
+        state_path = scenario_dir / "mwe_node_state.csv"
+        if not state_path.exists():
+            continue
+        state = load_node_state(scenario_dir)
+        rounds = latest_stabilization_time(scenario_dir)
+        depth = int(state["level"].max())
+        correct = bool(((state["status"] == "STABLE") & (state["proof_valid"].astype(int) == 1)).all())
+
+        rows.append(
+            {
+                "topology": infer_topology(scenario),
+                "depth": depth,
+                "algorithm": infer_algorithm(scenario),
+                "rounds_to_converge": rounds,
+                "correct_convergence": correct,
+            }
+        )
+
+    if not rows:
+        raise ValueError("Parsed vectors but no usable rows for convergence analysis")
+
+    out = pd.DataFrame(rows)
+    out = (
+        out.groupby(["topology", "depth", "algorithm"], as_index=False)
+        .agg(
+            rounds_to_converge=("rounds_to_converge", "mean"),
+            correct_convergence=("correct_convergence", "all"),
+        )
+    )
+    out["rounds_to_converge"] = out["rounds_to_converge"].round(6)
+    return out
 
 
 def plot_fig5(df: pd.DataFrame, out_path: Path) -> None:
     fig, axes = plt.subplots(1, 2, figsize=(13, 5), sharey=True)
     for ax, topology in zip(axes, ("Twitch", "CBT")):
         subset = df[df["topology"] == topology]
+        if subset.empty:
+            ax.set_title(f"{topology} convergence rounds")
+            ax.text(0.5, 0.5, "No data", transform=ax.transAxes, ha="center", va="center")
+            ax.axis("off")
+            continue
         sns.lineplot(
             data=subset,
             x="depth",
@@ -75,14 +152,13 @@ def plot_fig5(df: pd.DataFrame, out_path: Path) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("output_dir", help="Directory for fig5 outputs")
-    parser.add_argument("--max-depth", type=int, default=10)
-    parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument("--result-root", required=True, help="Result root containing scenario subdirs and .vec files")
     args = parser.parse_args()
 
     out_dir = Path(args.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    df = build_analysis(args.max_depth, args.seed)
+    df = build_analysis(Path(args.result_root))
     out_csv = out_dir / "analysis.csv"
     out_png = out_dir / "metrics_plot.png"
     df.to_csv(out_csv, index=False)


### PR DESCRIPTION
## Summary
- replaces synthetic fig2/fig3/fig5 metric generation with simulation-derived inputs
- exports richer node-state data (`level`, `parent_id`, `proof_size_bytes`) from OMNeT++ for traceable analysis
- updates CI smoke and docs to run figure scripts against real scenario outputs

## Validation
- `uv run python -m py_compile scripts/analysis/build_fig2_outputs.py scripts/analysis/build_fig3_outputs.py scripts/analysis/build_fig5_outputs.py`
- `RESULT_DIR=/tmp/scm-accuracy-full3 SCM_RANDOM_SEED=1337 ./scripts/run_experiments.sh --skip-sim-build`
- `uv run python scripts/analysis/build_fig2_outputs.py /tmp/scm-fig2-strict --result-root /tmp/scm-accuracy-full3`
- `uv run python scripts/analysis/build_fig3_outputs.py /tmp/scm-fig3-strict --cbt-state-dir /tmp/scm-accuracy-full3/BaselineCBT --twitch-state-dir /tmp/scm-accuracy-full3/BaselineER --twitch-nodes 50`
- `uv run python scripts/analysis/build_fig5_outputs.py /tmp/scm-fig5-strict --result-root /tmp/scm-accuracy-full3`
- `uv run python scripts/analysis/validate_outputs.py /tmp/scm-fig2-strict --require-columns topology,depth,avg_beta_pct_increase,avg_payment_pct_increase,user_fraction_receiving_service --require-non-empty`
- `uv run python scripts/analysis/validate_outputs.py /tmp/scm-fig3-strict --require-columns topology,num_nodes,method,avg_proof_size_bytes --require-non-empty`
- `uv run python scripts/analysis/validate_outputs.py /tmp/scm-fig5-strict --require-columns topology,depth,algorithm,rounds_to_converge,correct_convergence --require-non-empty`

Closes #30
