### PR TITLE
[PR-A] Claim matrix scaffold + deterministic depth fault campaign mode

### DIFF
--- a/omnetpp/simulations/networks/SCMFaultInjector.ned
+++ b/omnetpp/simulations/networks/SCMFaultInjector.ned
@@ -5,6 +5,12 @@ simple SCMFaultInjector {
         double faultProbability @default(0);  // Per-node probability of fault injection
         double interval @unit(s) @default(10s);  // Time between injection rounds
         double initialDelay @unit(s) @default(5s); // Delay before first injection
+        int campaignMode @default(0);  // 0=probabilistic per-node, 1=deterministic one-node-per-depth
+        int campaignSeed @default(1337);
+        int maxCampaignDepth @default(-1); // -1 means all depths
+        int parentOffset @default(1); // Used by deterministic parent-switch campaigns
+        bool strictDepthCampaign @default(true);
+        bool sendFaultNotify @default(true);
 
         @display("i=block/cogwheel,red");
 }

--- a/omnetpp/simulations/networks/SCMNode.ned
+++ b/omnetpp/simulations/networks/SCMNode.ned
@@ -4,6 +4,7 @@ simple SCMNode {
         int id;
         int numUsers;
         double linkCost @default(1.0);
+        string algorithmVariant @default("scm");
 
         @display("i=block/process");
 

--- a/omnetpp/simulations/omnetpp.ini
+++ b/omnetpp/simulations/omnetpp.ini
@@ -20,9 +20,16 @@ repeat = 3  # Run each scenario 3 times
 *.faultInjector.faultProbability = 0
 *.faultInjector.interval = 10s
 *.faultInjector.initialDelay = 5s
+*.faultInjector.campaignMode = 0
+*.faultInjector.campaignSeed = 1337
+*.faultInjector.maxCampaignDepth = -1
+*.faultInjector.parentOffset = 1
+*.faultInjector.strictDepthCampaign = true
+*.faultInjector.sendFaultNotify = true
 
 # Node defaults
 *.node[*].linkCost = 1.0
+*.node[*].algorithmVariant = "scm"
 
 #---------------------------
 # Baseline Configurations
@@ -91,3 +98,89 @@ description = "Parent switching faults"
 #description = "Comparison: Byrenheid's algorithm"
 #*.algorithmType = "byrenheid"
 #*.numNodes = 50
+
+#---------------------------
+# Claim-A matrix scaffolding (deterministic fault campaign + algorithm variant tags)
+#---------------------------
+
+# Figure-2 style CBT depth sweep
+[Config ClaimA_CBT_Baseline_D4]
+extends = BaselineCBT
+*.numNodes = 31
+
+[Config ClaimA_CBT_FaultParent_D4]
+extends = BaselineCBT
+*.numNodes = 31
+*.faultInjector.faultType = 2
+*.faultInjector.campaignMode = 1
+*.faultInjector.parentOffset = 1
+*.faultInjector.maxCampaignDepth = 4
+*.faultInjector.sendFaultNotify = false
+
+[Config ClaimA_CBT_Baseline_D5]
+extends = BaselineCBT
+*.numNodes = 63
+
+[Config ClaimA_CBT_FaultParent_D5]
+extends = BaselineCBT
+*.numNodes = 63
+*.faultInjector.faultType = 2
+*.faultInjector.campaignMode = 1
+*.faultInjector.parentOffset = 1
+*.faultInjector.maxCampaignDepth = 5
+*.faultInjector.sendFaultNotify = false
+
+[Config ClaimA_CBT_Baseline_D6]
+extends = BaselineCBT
+*.numNodes = 127
+
+[Config ClaimA_CBT_FaultParent_D6]
+extends = BaselineCBT
+*.numNodes = 127
+*.faultInjector.faultType = 2
+*.faultInjector.campaignMode = 1
+*.faultInjector.parentOffset = 1
+*.faultInjector.maxCampaignDepth = 6
+*.faultInjector.sendFaultNotify = false
+
+# Figure-2 style ER size sweep
+[Config ClaimA_ER_Baseline_N50]
+extends = BaselineER
+*.numNodes = 50
+*.connectionProbability = 0.2
+
+[Config ClaimA_ER_FaultBeta_N50]
+extends = BaselineER
+*.numNodes = 50
+*.connectionProbability = 0.2
+*.faultInjector.faultType = 1
+*.faultInjector.faultProbability = 0.15
+
+[Config ClaimA_ER_Baseline_N100]
+extends = BaselineER
+*.numNodes = 100
+*.connectionProbability = 0.12
+
+[Config ClaimA_ER_FaultBeta_N100]
+extends = BaselineER
+*.numNodes = 100
+*.connectionProbability = 0.12
+*.faultInjector.faultType = 1
+*.faultInjector.faultProbability = 0.15
+
+# Figure-5 style algorithm variant scaffolding (SCM behavior only in PR-A)
+[Config ClaimA_CBT_FaultParent_D5_GargStub]
+extends = ClaimA_CBT_FaultParent_D5
+*.node[*].algorithmVariant = "garg-grosu"
+*.faultInjector.parentOffset = 2
+
+[Config ClaimA_CBT_FaultParent_D5_ByrenheidStub]
+extends = ClaimA_CBT_FaultParent_D5
+*.node[*].algorithmVariant = "byrenheid"
+*.faultInjector.parentOffset = 2
+
+[Config ClaimA_Twitch_FaultParent_N256]
+extends = BaselineTwitch
+*.numNodes = 256
+*.faultInjector.faultType = 2
+*.faultInjector.faultProbability = 0.05

--- a/omnetpp/simulations/src/SCMFaultInjector.cc
+++ b/omnetpp/simulations/src/SCMFaultInjector.cc
@@ -1,14 +1,112 @@
 #include "SCMFaultInjector.h"
 #include "SCMNode.h"
 #include "SCMMessages.h"
+#include <algorithm>
+#include <cmath>
 
 using namespace omnetpp;
 
 Define_Module(SCMFaultInjector);
 
+int SCMFaultInjector::computeCbtDepthFromIndex(int nodeIndex) const
+{
+    int depth = 0;
+    int index = nodeIndex + 1;
+    while (index > 1) {
+        index >>= 1;
+        depth++;
+    }
+    return depth;
+}
+
+void SCMFaultInjector::buildDepthBuckets(int numNodes)
+{
+    depthBuckets.clear();
+    depthBuckets.resize(std::max(1, computeCbtDepthFromIndex(numNodes - 1) + 1));
+    cModule *network = getParentModule();
+    for (int i = 0; i < numNodes; i++) {
+        SCMNode *node = check_and_cast<SCMNode*>(network->getSubmodule("node", i));
+        int depth = node->getLevel();
+        if (depth < 0 || depth >= (int)depthBuckets.size()) {
+            depth = computeCbtDepthFromIndex(i);
+        }
+        depthBuckets[depth].push_back(i);
+    }
+}
+
+std::vector<int> SCMFaultInjector::selectDeterministicTargets() const
+{
+    std::vector<int> targets;
+    for (int depth = 0; depth < (int)depthBuckets.size(); depth++) {
+        if (depth == 0) {
+            continue;  // Never corrupt root
+        }
+        if (maxCampaignDepth >= 0 && depth > maxCampaignDepth) {
+            continue;
+        }
+        const auto &bucket = depthBuckets[depth];
+        if (bucket.empty()) {
+            continue;
+        }
+        int idx = (campaignSeed + campaignRound + depth) % (int)bucket.size();
+        targets.push_back(bucket[idx]);
+    }
+    return targets;
+}
+
+void SCMFaultInjector::notifyNodeFault(SCMNode *node)
+{
+    if (!sendFaultNotify) {
+        return;
+    }
+    SCMControlMessage *faultMsg = new SCMControlMessage("FaultNotify");
+    faultMsg->setMsgType(SCMControlMessage::FAULT_NOTIFY);
+    faultMsg->setSenderId(-1);  // From fault injector
+    sendDirect(faultMsg, node->gate("port$i", 0));
+}
+
+void SCMFaultInjector::applyFaultToNode(SCMNode *node, int numNodes)
+{
+    switch (faultType) {
+        case DISTANCE_TAMPER:
+            node->setLevel(node->getLevel() + 1);
+            node->bubble("DISTANCE TAMPERED");
+            break;
+
+        case BETA_MODIFICATION:
+            node->setBeta(node->getBeta() * 1.5);
+            node->bubble("BETA MODIFIED");
+            break;
+
+        case PARENT_SWITCH:
+            if (node->getId() != 0) { // Don't tamper with root
+                int newParent = (node->getParentId() + parentOffset) % numNodes;
+                if (newParent == node->getId()) {
+                    newParent = (newParent + 1) % numNodes;
+                }
+                node->setParentId(newParent);
+                node->bubble("PARENT SWITCHED");
+            }
+            break;
+    }
+    notifyNodeFault(node);
+}
+
 void SCMFaultInjector::initialize()
 {
     faultType = (FaultType)par("faultType").intValue();
+    campaignMode = (CampaignMode)par("campaignMode").intValue();
+    campaignSeed = par("campaignSeed").intValue();
+    campaignRound = 0;
+    maxCampaignDepth = par("maxCampaignDepth").intValue();
+    parentOffset = par("parentOffset").intValue();
+    strictDepthCampaign = par("strictDepthCampaign").boolValue();
+    sendFaultNotify = par("sendFaultNotify").boolValue();
+
+    if (parentOffset < 1) {
+        throw cRuntimeError("parentOffset must be >= 1");
+    }
+
     scheduleAt(simTime() + par("initialDelay").doubleValue(), 
               new cMessage("InjectFault"));
 }
@@ -17,6 +115,7 @@ void SCMFaultInjector::handleMessage(cMessage *msg)
 {
     if (msg->isSelfMessage() && strcmp(msg->getName(), "InjectFault") == 0) {
         injectFault();
+        campaignRound++;
         scheduleAt(simTime() + par("interval").doubleValue(), msg);
     } else {
         delete msg;
@@ -27,36 +126,30 @@ void SCMFaultInjector::injectFault()
 {
     cModule *network = getParentModule();
     int numNodes = network->par("numNodes");
-    
+
+    if (campaignMode == DETERMINISTIC_ONE_NODE_PER_DEPTH) {
+        const char *networkName = network->getNedTypeName();
+        bool cbtLike = std::string(networkName) == "CompleteBinaryTree";
+        if (!cbtLike && strictDepthCampaign) {
+            throw cRuntimeError("Deterministic depth campaign requires CompleteBinaryTree network; got %s", networkName);
+        }
+        if (!cbtLike) {
+            EV_WARN << "Skipping deterministic depth campaign on non-CBT network " << networkName << endl;
+            return;
+        }
+        buildDepthBuckets(numNodes);
+        auto targets = selectDeterministicTargets();
+        for (int nodeId : targets) {
+            SCMNode *node = check_and_cast<SCMNode*>(network->getSubmodule("node", nodeId));
+            applyFaultToNode(node, numNodes);
+        }
+        return;
+    }
+
     for (int i = 0; i < numNodes; i++) {
         if (uniform(0, 1) < par("faultProbability").doubleValue()) {
-            SCMNode *node = check_and_cast<SCMNode*>(
-                network->getSubmodule("node", i));
-            
-            switch (faultType) {
-                case DISTANCE_TAMPER:
-                    node->setLevel(node->getLevel() + 1);
-                    node->bubble("DISTANCE TAMPERED");
-                    break;
-                    
-                case BETA_MODIFICATION:
-                    node->setBeta(node->getBeta() * 1.5);
-                    node->bubble("BETA MODIFIED");
-                    break;
-                    
-                case PARENT_SWITCH:
-                    if (node->getId() != 0) { // Don't tamper with root
-                        node->setParentId((node->getParentId() + 1) % numNodes);
-                        node->bubble("PARENT SWITCHED");
-                    }
-                    break;
-            }
-            
-            // Notify the node about the fault via direct message delivery
-            SCMControlMessage *faultMsg = new SCMControlMessage("FaultNotify");
-            faultMsg->setMsgType(SCMControlMessage::FAULT_NOTIFY);
-            faultMsg->setSenderId(-1);  // From fault injector
-            sendDirect(faultMsg, node->gate("port$i", 0));
+            SCMNode *node = check_and_cast<SCMNode*>(network->getSubmodule("node", i));
+            applyFaultToNode(node, numNodes);
         }
     }
 }

--- a/omnetpp/simulations/src/SCMFaultInjector.h
+++ b/omnetpp/simulations/src/SCMFaultInjector.h
@@ -2,6 +2,7 @@
 #define SCMFAULTINJECTOR_H
 
 #include <omnetpp.h>
+#include <vector>
 
 class SCMFaultInjector : public omnetpp::cSimpleModule {
   public:
@@ -10,9 +11,28 @@ class SCMFaultInjector : public omnetpp::cSimpleModule {
         BETA_MODIFICATION,
         PARENT_SWITCH
     };
+    enum CampaignMode {
+        PROBABILISTIC_PER_NODE,
+        DETERMINISTIC_ONE_NODE_PER_DEPTH
+    };
     
   private:
     FaultType faultType;
+    CampaignMode campaignMode;
+    int campaignSeed;
+    int campaignRound;
+    int maxCampaignDepth;
+    int parentOffset;
+    bool strictDepthCampaign;
+    bool sendFaultNotify;
+
+    std::vector<std::vector<int>> depthBuckets;
+
+    int computeCbtDepthFromIndex(int nodeIndex) const;
+    void buildDepthBuckets(int numNodes);
+    std::vector<int> selectDeterministicTargets() const;
+    void applyFaultToNode(class SCMNode *node, int numNodes);
+    void notifyNodeFault(class SCMNode *node);
     void injectFault();
     
   protected:

--- a/omnetpp/simulations/src/SCMNode.cc
+++ b/omnetpp/simulations/src/SCMNode.cc
@@ -41,6 +41,12 @@ void SCMNode::initialize()
     id = par("id");
     numUsers = par("numUsers");
     linkCost = par("linkCost");
+    const char *variant = par("algorithmVariant").stringValue();
+    if (strcmp(variant, "scm") != 0) {
+        EV_WARN << "algorithmVariant=" << variant
+                << " requested on node " << id
+                << ", but only SCM behavior is implemented; using SCM logic." << endl;
+    }
 
     // Register signal for stabilization metrics
     stabilizationTimeSignal = registerSignal("nodeStableTime");

--- a/omnetpp/simulations/src/SCMNode.h
+++ b/omnetpp/simulations/src/SCMNode.h
@@ -109,6 +109,9 @@ class SCMNode : public omnetpp::cSimpleModule {
     int getParentId() const { return parentId; }
     int getLevel() const { return level; }
     double getBeta() const { return beta; }
+    const char* getStatusLabel() const {
+        return (status == STABLE) ? "STABLE" : (status == FAULTY) ? "FAULTY" : "RECOVERING";
+    }
     Status getStatus() const { return status; }
     double getPayment() const { return payment; }
     int getSubtreeSize() const { return subtreeSize; }

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -8,6 +8,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SKIP_SIM_BUILD=0
 QUICK_MODE=0
 MWE_MODE=0
+CLAIM_A_MODE=0
 
 usage() {
     cat <<'EOF'
@@ -19,6 +20,7 @@ Usage:
 Options:
     --quick              Run only BaselineCBT for a fast smoke test
     --mwe                Run only the artifact minimum working example
+    --claim-a            Run claim-matrix scaffold scenarios (PR-A)
     --skip-sim-build     Skip simulation binary build step
     -h, --help           Show this help
 
@@ -39,6 +41,10 @@ while [[ $# -gt 0 ]]; do
             MWE_MODE=1
             shift
             ;;
+        --claim-a)
+            CLAIM_A_MODE=1
+            shift
+            ;;
         --skip-sim-build)
             SKIP_SIM_BUILD=1
             shift
@@ -54,6 +60,11 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if [[ "$MWE_MODE" -eq 1 && "$CLAIM_A_MODE" -eq 1 ]]; then
+    echo "ERROR: --mwe and --claim-a cannot be combined" >&2
+    exit 2
+fi
 
 if ! command -v uv >/dev/null 2>&1; then
     echo "ERROR: uv is required but not found in PATH." >&2
@@ -127,15 +138,46 @@ if [[ "$MWE_MODE" -eq 1 ]]; then
     fi
     export MWE_NUM_NODES
     configs=(MWE)
+elif [[ "$CLAIM_A_MODE" -eq 1 ]]; then
+    if [[ "$QUICK_MODE" -eq 1 ]]; then
+        configs=(
+            ClaimA_CBT_Baseline_D5
+            ClaimA_CBT_FaultParent_D5
+            ClaimA_CBT_FaultParent_D5_GargStub
+            ClaimA_CBT_FaultParent_D5_ByrenheidStub
+        )
+    else
+        configs=(
+            ClaimA_CBT_Baseline_D4
+            ClaimA_CBT_FaultParent_D4
+            ClaimA_CBT_Baseline_D5
+            ClaimA_CBT_FaultParent_D5
+            ClaimA_CBT_Baseline_D6
+            ClaimA_CBT_FaultParent_D6
+            ClaimA_ER_Baseline_N50
+            ClaimA_ER_FaultBeta_N50
+            ClaimA_ER_Baseline_N100
+            ClaimA_ER_FaultBeta_N100
+            ClaimA_CBT_FaultParent_D5_GargStub
+            ClaimA_CBT_FaultParent_D5_ByrenheidStub
+            ClaimA_Twitch_FaultParent_N256
+        )
+    fi
 elif [[ "$QUICK_MODE" -eq 1 ]]; then
     configs=(BaselineCBT)
 else
     configs=(BaselineCBT FaultDistance BaselineER FaultBeta)
 fi
 
+if [[ "$CLAIM_A_MODE" -eq 1 ]]; then
+    sim_root="$RESULT_DIR/claim-a"
+else
+    sim_root="$RESULT_DIR"
+fi
+
 for config in "${configs[@]}"; do
     echo "Running $config..."
-    config_result_dir="$RESULT_DIR/$config"
+    config_result_dir="$sim_root/$config"
     if [[ "$MWE_MODE" -eq 1 ]]; then
         ./scm-simulations -u Cmdenv -c "$config" -n networks \
             --result-dir="$config_result_dir" \
@@ -152,10 +194,10 @@ if [[ "$MWE_MODE" -eq 1 ]]; then
     uv run python "$SCRIPT_DIR/analysis/build_mwe_outputs.py" "$RESULT_DIR/MWE" "$mwe_root"
 else
     # Process results
-    uv run python "$SCRIPT_DIR/analysis/process_results.py" "$RESULT_DIR"
+    uv run python "$SCRIPT_DIR/analysis/process_results.py" "$sim_root"
 
     # Generate visualizations
-    uv run python "$SCRIPT_DIR/visualization/plot_metrics.py" "$RESULT_DIR"
+    uv run python "$SCRIPT_DIR/visualization/plot_metrics.py" "$sim_root"
 fi
 
 echo "Experiment pipeline completed"


### PR DESCRIPTION
## Summary
PR-A introduces claim-matrix scaffolding and deterministic fault-campaign plumbing while preserving existing default flows.

### What this PR adds
- Deterministic fault campaign mode in `SCMFaultInjector`:
  - `campaignMode=1` selects one node per depth deterministically on CBT
  - configurable `campaignSeed`, `maxCampaignDepth`, `parentOffset`, and `sendFaultNotify`
- New injector parameters in `SCMFaultInjector.ned` with backward-compatible defaults.
- `algorithmVariant` parameter scaffold in `SCMNode` (`scm`, `garg-grosu`, `byrenheid`) with explicit SCM fallback warning.
- New `--claim-a` mode in `scripts/run_experiments.sh` to run claim-matrix scaffold scenarios.
- New `ClaimA_*` scenario family in `omnetpp.ini` for depth/size sweeps and algorithm-tag scaffolding.

### Behavior compatibility
- Existing `--quick`, default full, and `--mwe` flows remain unchanged.
- `--claim-a` writes results under `RESULT_DIR/claim-a` to isolate scaffold runs.

## Validation
- `RESULT_DIR=/tmp/scm-claima-quick SCM_RANDOM_SEED=1337 ./scripts/run_experiments.sh --claim-a --quick`
- `uv run python scripts/analysis/validate_outputs.py /tmp/scm-claima-quick/claim-a --require-columns scenario,value_mean,value_std,value_count,time_max --require-non-empty`
- `uv run python -m unittest tests/test_preprocess.py -v`

## Scope note
This PR is scaffolding only. It does not yet implement real Garg-Grosu/Byrenheid algorithm logic or full claim-level figure methodology.
