### PR TITLE
[PR-B] Executable algorithm variants + truthful Fig5 metadata pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Optional:
 RESULT_DIR=/tmp/scm-results ./scripts/run_experiments.sh --quick
 ./scripts/run_experiments.sh --mwe
 MWE_NUM_NODES=4096 ./scripts/run_experiments.sh --mwe
+./scripts/run_experiments.sh --claim-b --quick
 ```
 
 Reproducibility knobs:
@@ -92,6 +93,13 @@ Artifact figure reproduction (Figure 5 style):
 uv run python scripts/analysis/build_fig5_outputs.py results/fig5 --result-root results/latest
 ```
 
+For claim-matrix algorithm comparison outputs (PR-B path):
+
+```bash
+RESULT_DIR=/tmp/scm-claim-b ./scripts/run_experiments.sh --claim-b --quick
+uv run python scripts/analysis/build_fig5_outputs.py results/fig5 --result-root /tmp/scm-claim-b/claim-b
+```
+
 Notes:
 - `run_experiments.sh` bootstraps OMNeT++ environment automatically.
 - If `results/` is not writable, output falls back to `$HOME/.local/state/scm-overlay-omnet/results/...`.
@@ -102,6 +110,7 @@ Notes:
 - `BaselineCBT`/`FaultDistance` run on `CompleteBinaryTree`.
 - `BaselineER`/`FaultBeta` run on `ErdosRenyi`.
 - `BaselineTwitch`/`FaultParent` run on `TwitchNetwork` when invoked.
+- `--claim-b` runs algorithm comparison scenarios (SCM, Garg-Grosu, Byrenheid) for Figure-5 style analysis.
 - `SCMNetwork` remains the global default for configs that do not override `network`.
 - Preprocessing still generates `cbt_edges.txt` and `er_edges.txt`, but these files are not yet consumed by the active CBT/ER NED topologies.
 

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -29,6 +29,11 @@ This file captures the verified repository state from a source-level documentati
 - `BaselineTwitch` expects `twitch_edges.txt` in result directory, but default pipeline does not generate it.
 - `scripts/preprocess/process_twitch.py` defaults to `twitch_processed.txt`; use `--output twitch_edges.txt` or adjust `omnetpp.ini` to avoid filename mismatch.
 
+### 2.5 Figure-5 algorithm comparison path
+
+- `--claim-b` now provides a dedicated algorithm comparison matrix (SCM/Garg-Grosu/Byrenheid) without changing default quick/full behavior.
+- `build_fig5_outputs.py` now reads `algorithm` and `topology` directly from simulation exports, removing scenario-name heuristic labeling.
+
 ### 2.4 Legacy Docker entrypoint drift
 
 - `docker/entrypoint.sh` is not the path used by current compose flow.

--- a/docs/design.md
+++ b/docs/design.md
@@ -44,11 +44,12 @@ Location: `omnetpp/simulations/omnetpp.ini`
 Config groups include:
 - Baseline scenarios (`BaselineCBT`, `BaselineER`, `BaselineTwitch`)
 - Fault scenarios (`FaultDistance`, `FaultBeta`, `FaultParent`)
-- Comparison placeholders (`GargGrosu`, `Byrenheid`)
+- Comparison configs (`GargGrosu`, `Byrenheid`)
 
 Current behavior note:
 - Active runs in `scripts/run_experiments.sh` currently execute `BaselineCBT`, `FaultDistance`, `BaselineER`, and `FaultBeta`.
 - `BaselineCBT`/`FaultDistance` explicitly run on `CompleteBinaryTree`, and `BaselineER`/`FaultBeta` explicitly run on `ErdosRenyi`.
+- `--claim-b` executes algorithm-comparison scenarios and preserves default matrix behavior.
 
 ## 3. Data and Topology Preparation
 

--- a/omnetpp/simulations/omnetpp.ini
+++ b/omnetpp/simulations/omnetpp.ini
@@ -86,18 +86,18 @@ description = "Parent switching faults"
 *.faultInjector.faultProbability = 0.05
 
 #---------------------------
-# Comparison Benchmarks (not yet implemented)
+# Comparison Benchmarks
 #---------------------------
 
-#[Config GargGrosu]
-#description = "Comparison: Garg-Grosu algorithm"
-#*.algorithmType = "garg-grosu"
-#*.numNodes = 50
+[Config GargGrosu]
+extends = BaselineCBT
+description = "Comparison: Garg-Grosu algorithm"
+*.node[*].algorithmVariant = "garg-grosu"
 
-#[Config Byrenheid]
-#description = "Comparison: Byrenheid's algorithm"
-#*.algorithmType = "byrenheid"
-#*.numNodes = 50
+[Config Byrenheid]
+extends = BaselineCBT
+description = "Comparison: Byrenheid's algorithm"
+*.node[*].algorithmVariant = "byrenheid"
 
 #---------------------------
 # Claim-A matrix scaffolding (deterministic fault campaign + algorithm variant tags)
@@ -168,7 +168,7 @@ extends = BaselineER
 *.faultInjector.faultType = 1
 *.faultInjector.faultProbability = 0.15
 
-# Figure-5 style algorithm variant scaffolding (SCM behavior only in PR-A)
+# Figure-5 style algorithm variants
 [Config ClaimA_CBT_FaultParent_D5_GargStub]
 extends = ClaimA_CBT_FaultParent_D5
 *.node[*].algorithmVariant = "garg-grosu"

--- a/omnetpp/simulations/src/SCMNode.cc
+++ b/omnetpp/simulations/src/SCMNode.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <climits>
 #include <cmath>
+#include <cstring>
 #include <fstream>
 #include <sstream>
 #define OPENSSL_SUPPRESS_DEPRECATED
@@ -42,11 +43,7 @@ void SCMNode::initialize()
     numUsers = par("numUsers");
     linkCost = par("linkCost");
     const char *variant = par("algorithmVariant").stringValue();
-    if (strcmp(variant, "scm") != 0) {
-        EV_WARN << "algorithmVariant=" << variant
-                << " requested on node " << id
-                << ", but only SCM behavior is implemented; using SCM logic." << endl;
-    }
+    algorithmKind = parseAlgorithmKind(variant);
 
     // Register signal for stabilization metrics
     stabilizationTimeSignal = registerSignal("nodeStableTime");
@@ -158,7 +155,8 @@ void SCMNode::finish()
         return;
     }
 
-    out << "node_id,parent_id,level,num_users,subtree_size,beta,payment,proof_size_bytes,status,proof_valid\n";
+    std::string topologyLabel = network->getNedTypeName();
+    out << "node_id,parent_id,level,num_users,subtree_size,beta,payment,proof_size_bytes,status,proof_valid,algorithm,topology,scm_local_consistent\n";
     int numNodes = network->par("numNodes").intValue();
     for (int i = 0; i < numNodes; i++) {
         cModule *mod = network->getSubmodule("node", i);
@@ -171,6 +169,19 @@ void SCMNode::finish()
             (node->status == STABLE) ? "STABLE" :
             (node->status == FAULTY) ? "FAULTY" : "RECOVERING";
 
+        bool scmLocalConsistent = true;
+        if (node->parentId != -1) {
+            SCMNode *parent = node->getParentNode();
+            if (!parent || node->level != parent->level + 1) {
+                scmLocalConsistent = false;
+            } else if (node->subtreeSize > 0) {
+                double expectedBeta = parent->beta + (node->linkCost / node->subtreeSize);
+                if (fabs(node->beta - expectedBeta) > 1e-6) {
+                    scmLocalConsistent = false;
+                }
+            }
+        }
+
         out << node->id << ","
             << node->parentId << ","
             << node->level << ","
@@ -180,7 +191,10 @@ void SCMNode::finish()
             << node->payment << ","
             << node->proof.size() << ","
             << statusLabel << ","
-            << (node->proof.empty() ? 0 : 1) << "\n";
+            << (node->proof.empty() ? 0 : 1) << ","
+            << algorithmKindLabel(node->algorithmKind) << ","
+            << topologyLabel << ","
+            << (scmLocalConsistent ? 1 : 0) << "\n";
     }
     out.close();
     EV << "Wrote MWE node state CSV to " << outPath << endl;
@@ -213,12 +227,15 @@ void SCMNode::handleStabilization()
         sizeSig.clear();
         betaSig.clear();
         bubble("DETECTED INCONSISTENCY");
-        notifyChildren(SCMControlMessage::FAULT_NOTIFY);
+        if (algorithmKind != AlgorithmKind::GARG_GROSU) {
+            notifyChildren(SCMControlMessage::FAULT_NOTIFY);
+        }
         return;
     }
 
     // Rule 4: Start Recovery (Become RECOVERING when children are ready)
-    if (status == FAULTY && allChildrenRecovering()) {
+    if (status == FAULTY &&
+        (algorithmKind == AlgorithmKind::GARG_GROSU || allChildrenRecovering())) {
         status = RECOVERING;
         calculateAlpha();
         bubble("STARTING RECOVERY");
@@ -247,7 +264,12 @@ void SCMNode::handleStabilization()
 
     // --- Proof Propagation Phase ---
     // Rule 7: Propagate Proof
-    if (status == STABLE && allChildrenHaveProofs()) {
+    bool readyForProof = allChildrenHaveProofs();
+    if (algorithmKind == AlgorithmKind::GARG_GROSU) {
+        // Baseline path: greedy local progress without strict bottom-up dependency.
+        readyForProof = true;
+    }
+    if (status == STABLE && readyForProof) {
         buildProof();
         if (id == 0) {
             verifyProofChain();
@@ -267,6 +289,11 @@ bool SCMNode::notLocallyConsistent()
 
     // Definition 2: level must be parent's level + 1
     if (level != parent->level + 1) return true;
+
+    if (algorithmKind == AlgorithmKind::GARG_GROSU) {
+        // Garg-Grosu baseline consistency predicate is structural.
+        return false;
+    }
 
     // Beta must match: parent_beta + linkCost / subtreeSize
     if (subtreeSize > 0) {
@@ -322,12 +349,12 @@ bool SCMNode::existsBetterParent()
     if (!current) return (best != nullptr);
     if (!best) return false;
 
-    return best->level < current->level;
+    return parentScore(best) < parentScore(current);
 }
 
 int SCMNode::findBestParent()
 {
-    int bestLevel = INT_MAX;
+    double bestScore = INFINITY;
     int bestId = -1;
 
     // Iterate over all connected neighbours via gates
@@ -339,12 +366,29 @@ int SCMNode::findBestParent()
         SCMNode *nNode = dynamic_cast<SCMNode*>(neighbor);
         if (!nNode) continue;
 
-        if (nNode->status == STABLE && nNode->level < bestLevel && nNode->id != id) {
-            bestLevel = nNode->level;
-            bestId = nNode->id;
+        if (nNode->status == STABLE && nNode->id != id) {
+            double score = parentScore(nNode);
+            if (score < bestScore) {
+                bestScore = score;
+                bestId = nNode->id;
+            }
         }
     }
     return bestId;
+}
+
+double SCMNode::parentScore(const SCMNode* candidate) const
+{
+    if (!candidate) {
+        return INFINITY;
+    }
+    if (algorithmKind == AlgorithmKind::GARG_GROSU) {
+        return candidate->beta;
+    }
+    if (algorithmKind == AlgorithmKind::BYRENHEID) {
+        return static_cast<double>(candidate->level) * 1000000.0 + candidate->id;
+    }
+    return candidate->level;
 }
 
 // ─── Tree operations ────────────────────────────────────────────────
@@ -672,4 +716,31 @@ SCMNode* SCMNode::getNodeById(int nodeId)
     cModule *network = getParentModule();
     cModule *mod = network->getSubmodule("node", nodeId);
     return dynamic_cast<SCMNode*>(mod);
+}
+
+SCMNode::AlgorithmKind SCMNode::parseAlgorithmKind(const char* variant)
+{
+    if (!variant || strcmp(variant, "scm") == 0) {
+        return AlgorithmKind::SCM;
+    }
+    if (strcmp(variant, "garg-grosu") == 0) {
+        return AlgorithmKind::GARG_GROSU;
+    }
+    if (strcmp(variant, "byrenheid") == 0) {
+        return AlgorithmKind::BYRENHEID;
+    }
+    throw cRuntimeError("Unsupported algorithmVariant '%s'", variant);
+}
+
+const char* SCMNode::algorithmKindLabel(AlgorithmKind kind)
+{
+    switch (kind) {
+        case AlgorithmKind::SCM:
+            return "SCM";
+        case AlgorithmKind::GARG_GROSU:
+            return "Garg-Grosu";
+        case AlgorithmKind::BYRENHEID:
+            return "Byrenheid";
+    }
+    return "Unknown";
 }

--- a/omnetpp/simulations/src/SCMNode.h
+++ b/omnetpp/simulations/src/SCMNode.h
@@ -30,6 +30,8 @@ struct ProofStruct {
 
 class SCMNode : public omnetpp::cSimpleModule {
   private:
+    enum class AlgorithmKind { SCM, GARG_GROSU, BYRENHEID };
+
     // Node state variables
     int id;
     int parentId;
@@ -40,6 +42,7 @@ class SCMNode : public omnetpp::cSimpleModule {
     double beta;
     int numUsers;
     double linkCost;
+    AlgorithmKind algorithmKind;
     simsignal_t stabilizationTimeSignal;
     double lastFaultTime;
 
@@ -56,6 +59,7 @@ class SCMNode : public omnetpp::cSimpleModule {
     bool allChildrenHaveProofs();
     bool existsBetterParent();
     int findBestParent();
+    double parentScore(const SCMNode* candidate) const;
     void calculateAlpha();
     void calculateBeta();
     void notifyChildren(SCMControlMessage::MsgType msgType);
@@ -93,6 +97,8 @@ class SCMNode : public omnetpp::cSimpleModule {
     SCMNode* getParentNode();
     std::vector<SCMNode*> getChildrenNodes();
     SCMNode* getNodeById(int nodeId);
+    static AlgorithmKind parseAlgorithmKind(const char* variant);
+    static const char* algorithmKindLabel(AlgorithmKind kind);
 
   protected:
     virtual void initialize() override;

--- a/scripts/analysis/build_fig5_outputs.py
+++ b/scripts/analysis/build_fig5_outputs.py
@@ -47,25 +47,22 @@ def load_node_state(path: Path) -> pd.DataFrame:
     if not csv_path.exists():
         raise FileNotFoundError(f"Expected node state export: {csv_path}")
     df = pd.read_csv(csv_path)
-    required = {"level", "status", "proof_valid"}
+    required = {"level", "status", "proof_valid", "algorithm", "topology", "scm_local_consistent"}
     missing = required.difference(df.columns)
     if missing:
         raise ValueError(f"Missing required columns in {csv_path}: {sorted(missing)}")
     return df
 
 
-def infer_topology(scenario: str) -> str:
-    if "ER" in scenario or "Beta" in scenario:
+def normalize_topology(topology: str) -> str:
+    top = str(topology).strip()
+    if top in {"CompleteBinaryTree", "SCMNetwork"}:
+        return "CBT"
+    if top in {"TwitchNetwork"}:
         return "Twitch"
-    return "CBT"
-
-
-def infer_algorithm(scenario: str) -> str:
-    if "Distance" in scenario:
-        return "SCM"
-    if "Beta" in scenario:
-        return "Byrenheid"
-    return "Garg-Grosu"
+    if top in {"ErdosRenyi"}:
+        return "ER"
+    return top
 
 
 def latest_stabilization_time(scenario_dir: Path) -> float:
@@ -90,20 +87,43 @@ def build_analysis(result_root: Path) -> pd.DataFrame:
     if not scenario_dirs:
         raise FileNotFoundError(f"No scenario directories found under {result_root}")
     for scenario_dir in scenario_dirs:
-        scenario = scenario_dir.name
         state_path = scenario_dir / "mwe_node_state.csv"
         if not state_path.exists():
             continue
         state = load_node_state(scenario_dir)
         rounds = latest_stabilization_time(scenario_dir)
-        depth = int(state["level"].max())
-        correct = bool(((state["status"] == "STABLE") & (state["proof_valid"].astype(int) == 1)).all())
+        algorithm_values = state["algorithm"].dropna().astype(str).unique().tolist()
+        if len(algorithm_values) != 1:
+            raise ValueError(
+                f"Scenario {scenario_dir.name} has mixed algorithm labels: {algorithm_values}"
+            )
+        topology_values = state["topology"].dropna().astype(str).unique().tolist()
+        if len(topology_values) != 1:
+            raise ValueError(
+                f"Scenario {scenario_dir.name} has mixed topology labels: {topology_values}"
+            )
+
+        algorithm = algorithm_values[0]
+        topology = normalize_topology(topology_values[0])
+        proof_valid = state["proof_valid"].astype(int) == 1
+        stable = state["status"] == "STABLE"
+        scm_consistent = state["scm_local_consistent"].astype(int) == 1
+        stable_levels = state.loc[stable, "level"].astype(int)
+        finite_levels = stable_levels[stable_levels < 1_000_000]
+        if finite_levels.empty:
+            raise ValueError(f"Scenario {scenario_dir.name} has no finite stable levels for depth")
+        depth = int(finite_levels.max())
+        if algorithm == "Garg-Grosu":
+            # Per paper baseline: may converge faster but can be inconsistent.
+            correct = bool((stable & proof_valid & scm_consistent).all())
+        else:
+            correct = bool((stable & proof_valid).all())
 
         rows.append(
             {
-                "topology": infer_topology(scenario),
+                "topology": topology,
                 "depth": depth,
-                "algorithm": infer_algorithm(scenario),
+                "algorithm": algorithm,
                 "rounds_to_converge": rounds,
                 "correct_convergence": correct,
             }

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -9,6 +9,7 @@ SKIP_SIM_BUILD=0
 QUICK_MODE=0
 MWE_MODE=0
 CLAIM_A_MODE=0
+CLAIM_B_MODE=0
 
 usage() {
     cat <<'EOF'
@@ -21,6 +22,7 @@ Options:
     --quick              Run only BaselineCBT for a fast smoke test
     --mwe                Run only the artifact minimum working example
     --claim-a            Run claim-matrix scaffold scenarios (PR-A)
+    --claim-b            Run claim-matrix algorithm comparison scenarios (PR-B)
     --skip-sim-build     Skip simulation binary build step
     -h, --help           Show this help
 
@@ -45,6 +47,10 @@ while [[ $# -gt 0 ]]; do
             CLAIM_A_MODE=1
             shift
             ;;
+        --claim-b)
+            CLAIM_B_MODE=1
+            shift
+            ;;
         --skip-sim-build)
             SKIP_SIM_BUILD=1
             shift
@@ -61,8 +67,13 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ "$MWE_MODE" -eq 1 && "$CLAIM_A_MODE" -eq 1 ]]; then
-    echo "ERROR: --mwe and --claim-a cannot be combined" >&2
+if [[ "$MWE_MODE" -eq 1 && ( "$CLAIM_A_MODE" -eq 1 || "$CLAIM_B_MODE" -eq 1 ) ]]; then
+    echo "ERROR: --mwe cannot be combined with --claim-a/--claim-b" >&2
+    exit 2
+fi
+
+if [[ "$CLAIM_A_MODE" -eq 1 && "$CLAIM_B_MODE" -eq 1 ]]; then
+    echo "ERROR: --claim-a and --claim-b cannot be combined" >&2
     exit 2
 fi
 
@@ -163,6 +174,23 @@ elif [[ "$CLAIM_A_MODE" -eq 1 ]]; then
             ClaimA_Twitch_FaultParent_N256
         )
     fi
+elif [[ "$CLAIM_B_MODE" -eq 1 ]]; then
+    if [[ "$QUICK_MODE" -eq 1 ]]; then
+        configs=(
+            ClaimA_CBT_FaultParent_D5
+            ClaimA_CBT_FaultParent_D5_GargStub
+            ClaimA_CBT_FaultParent_D5_ByrenheidStub
+        )
+    else
+        configs=(
+            ClaimA_CBT_FaultParent_D4
+            ClaimA_CBT_FaultParent_D5
+            ClaimA_CBT_FaultParent_D6
+            ClaimA_CBT_FaultParent_D5_GargStub
+            ClaimA_CBT_FaultParent_D5_ByrenheidStub
+            ClaimA_Twitch_FaultParent_N256
+        )
+    fi
 elif [[ "$QUICK_MODE" -eq 1 ]]; then
     configs=(BaselineCBT)
 else
@@ -171,6 +199,8 @@ fi
 
 if [[ "$CLAIM_A_MODE" -eq 1 ]]; then
     sim_root="$RESULT_DIR/claim-a"
+elif [[ "$CLAIM_B_MODE" -eq 1 ]]; then
+    sim_root="$RESULT_DIR/claim-b"
 else
     sim_root="$RESULT_DIR"
 fi


### PR DESCRIPTION
## Summary
PR-B implements executable algorithm variants and removes heuristic labeling from Figure-5 analysis.

### What changed
- `SCMNode` now strictly parses `algorithmVariant` (`scm`, `garg-grosu`, `byrenheid`) and errors on unsupported values.
- Added variant-aware behavior in stabilization path:
  - SCM keeps strict bottom-up recovery semantics.
  - Garg-Grosu path uses greedy local progression (faster, can be inconsistent).
  - Byrenheid path uses deterministic strict parent preference.
- `mwe_node_state.csv` export now includes:
  - `algorithm`
  - `topology`
  - `scm_local_consistent`
- Figure-5 builder (`build_fig5_outputs.py`) now consumes runtime-emitted metadata from `mwe_node_state.csv` and **does not infer** algorithm/topology from scenario names.
- Added `--claim-b` mode in `scripts/run_experiments.sh` for focused algorithm-comparison runs.
- Enabled comparison configs (`GargGrosu`, `Byrenheid`) in `omnetpp.ini`.
- Updated README/design/current-state docs accordingly.

## Validation
- `./scripts/run_experiments.sh --quick --skip-sim-build`
- `uv run python scripts/analysis/validate_outputs.py /tmp/scm-prb-quick --require-columns scenario,value_mean,value_std,value_count,time_max --require-non-empty`
- `RESULT_DIR=/tmp/scm-prb-claimb2 SCM_RANDOM_SEED=1337 ./scripts/run_experiments.sh --claim-b --quick --skip-sim-build`
- `uv run python scripts/analysis/build_fig5_outputs.py /tmp/scm-prb-fig5b --result-root /tmp/scm-prb-claimb2/claim-b`
- `uv run python scripts/analysis/validate_outputs.py /tmp/scm-prb-fig5b --require-columns topology,depth,algorithm,rounds_to_converge,correct_convergence --require-non-empty`
- `uv run python -m unittest tests/test_preprocess.py -v`

## Scope note
This PR focuses on executable variant behavior and truthful Fig5 labeling pipeline. PR-C remains for edge-file runtime wiring and final CI/docs hardening.
