### PR TITLE
[PR-C] Runtime edge-file wiring + preprocess/CI/docs hardening

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -65,3 +65,22 @@ jobs:
             scm-overlay-omnet:ci \
             /workspace/.venv/bin/python \
             /workspace/scripts/analysis/validate_outputs.py /tmp/results/fig2-smoke --require-columns topology,depth,avg_beta_pct_increase,avg_payment_pct_increase,user_fraction_receiving_service --require-non-empty
+
+      - name: Validate claim-b fig5 smoke output
+        run: |
+          docker run --rm \
+            -v "$RUNNER_TEMP/scm-results:/tmp/results" \
+            -e RESULT_DIR=/tmp/results \
+            -e SCM_RANDOM_SEED=1337 \
+            scm-overlay-omnet:ci \
+            /bin/bash -lc "cd /workspace && ./scripts/run_experiments.sh --claim-b --quick --skip-sim-build"
+          docker run --rm \
+            -v "$RUNNER_TEMP/scm-results:/tmp/results" \
+            scm-overlay-omnet:ci \
+            /workspace/.venv/bin/python \
+            /workspace/scripts/analysis/build_fig5_outputs.py /tmp/results/fig5-smoke --result-root /tmp/results/claim-b
+          docker run --rm \
+            -v "$RUNNER_TEMP/scm-results:/tmp/results" \
+            scm-overlay-omnet:ci \
+            /workspace/.venv/bin/python \
+            /workspace/scripts/analysis/validate_outputs.py /tmp/results/fig5-smoke --require-columns topology,depth,algorithm,rounds_to_converge,correct_convergence --require-non-empty

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Notes:
 - `BaselineTwitch`/`FaultParent` run on `TwitchNetwork` when invoked.
 - `--claim-b` runs algorithm comparison scenarios (SCM, Garg-Grosu, Byrenheid) for Figure-5 style analysis.
 - `SCMNetwork` remains the global default for configs that do not override `network`.
-- Preprocessing still generates `cbt_edges.txt` and `er_edges.txt`, but these files are not yet consumed by the active CBT/ER NED topologies.
+- Preprocessing-generated `cbt_edges.txt` and `er_edges.txt` are now consumed by active CBT/ER runtime initializers.
 
 See `docs/current-state.md` for known gaps and caveats.
 

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -17,10 +17,11 @@ This file captures the verified repository state from a source-level documentati
 - `BaselineER` and `FaultBeta` explicitly run on `ErdosRenyi`.
 - `SCMNetwork` remains the global default for configs that do not set `network` in scenario config.
 
-### 2.2 Preprocessing artifacts are not fully wired into active topology behavior
+### 2.2 Edge-file wiring status
 
-- `run_experiments.sh` generates `cbt_edges.txt` and `er_edges.txt`.
-- The active `SCMNetwork` currently creates random links directly in NED and does not consume those generated edge files.
+- `run_experiments.sh` generates `cbt_edges.txt` and `er_edges.txt` per run.
+- `CompleteBinaryTree` and `ErdosRenyi` now consume these files via runtime initializer modules.
+- Invalid/missing edge files fail fast during network initialization.
 
 ### 2.3 Twitch scenario is not part of default pipeline
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -63,7 +63,7 @@ These scripts are intended to create topology inputs before simulation runs.
 
 Current integration note:
 - CBT/ER preprocess scripts generate edge files into the run directory.
-- Active CBT/ER scenarios now run on dedicated NED topologies (`CompleteBinaryTree`, `ErdosRenyi`), but these NED topologies still do not consume generated edge-list files directly.
+- Active CBT/ER scenarios run on dedicated NED topologies (`CompleteBinaryTree`, `ErdosRenyi`) and consume generated `cbt_edges.txt` / `er_edges.txt` via runtime edge-file initializers.
 - Twitch preprocessing exists but is not part of the default run matrix.
 
 ## 4. Experiment Orchestration

--- a/omnetpp/simulations/networks/CompleteBinaryTree.ned
+++ b/omnetpp/simulations/networks/CompleteBinaryTree.ned
@@ -3,11 +3,17 @@ network CompleteBinaryTree
 {
     parameters:
         int numNodes @default(31);
+        string edgeFilePath @default("");
         double faultProbability @default(0);
         double faultInterval @unit(s) @default(10s);
         @display("bgb=800,600");
 
     submodules:
+        initializer: EdgeFileNetworkInitializer {
+            edgeFilePath = parent.edgeFilePath;
+            @display("p=50,80");
+        }
+
         faultInjector: SCMFaultInjector {
             faultProbability = parent.faultProbability;
             interval = parent.faultInterval;
@@ -21,9 +27,5 @@ network CompleteBinaryTree
         }
 
     connections allowunconnected:
-        // Tree connections built programmatically by CBTBuilder
-        // or via NED loops for parent-child pairs:
-        for i=1..numNodes-1 {
-            node[i].port++ <--> { delay = 100ms; } <--> node[int((i-1)/2)].port++;
-        }
+        // Connections are created by EdgeFileNetworkInitializer from edgeFilePath.
 }

--- a/omnetpp/simulations/networks/EdgeFileNetworkInitializer.ned
+++ b/omnetpp/simulations/networks/EdgeFileNetworkInitializer.ned
@@ -1,0 +1,6 @@
+simple EdgeFileNetworkInitializer {
+    parameters:
+        string edgeFilePath;
+
+        @display("i=block/table,blue");
+}

--- a/omnetpp/simulations/networks/ErdosRenyi.ned
+++ b/omnetpp/simulations/networks/ErdosRenyi.ned
@@ -3,12 +3,18 @@ network ErdosRenyi
 {
     parameters:
         int numNodes @default(20);
+        string edgeFilePath @default("");
         double connectionProbability @default(0.3);
         double faultProbability @default(0);
         double faultInterval @unit(s) @default(10s);
         @display("bgb=800,600");
     
     submodules:
+        initializer: EdgeFileNetworkInitializer {
+            edgeFilePath = parent.edgeFilePath;
+            @display("p=50,80");
+        }
+
         faultInjector: SCMFaultInjector {
             faultProbability = parent.faultProbability;
             interval = parent.faultInterval;
@@ -22,12 +28,5 @@ network ErdosRenyi
         }
     
     connections allowunconnected:
-        // Random connections with given probability
-        for i=0..numNodes-2, for j=i+1..numNodes-1 {
-            node[i].port++ <--> { 
-                delay = 100ms; 
-                @display("ls=blue,1");
-            } <--> node[j].port++ 
-                if uniform(0,1) < connectionProbability;
-        }
+        // Connections are created by EdgeFileNetworkInitializer from edgeFilePath.
 }

--- a/omnetpp/simulations/omnetpp.ini
+++ b/omnetpp/simulations/omnetpp.ini
@@ -39,6 +39,7 @@ repeat = 3  # Run each scenario 3 times
 description = "Complete Binary Tree baseline"
 network = CompleteBinaryTree
 *.numNodes = 31  # 2^5-1
+*.edgeFilePath = "${resultdir}/cbt_edges.txt"
 *.faultInjector.faultProbability = 0
 
 [Config MWE]
@@ -47,12 +48,14 @@ network = CompleteBinaryTree
 sim-time-limit = 12s
 repeat = 1
 *.numNodes = 1024
+*.edgeFilePath = "${resultdir}/cbt_edges.txt"
 *.faultInjector.faultProbability = 0
 
 [Config BaselineER]
 description = "Erdos-Renyi baseline"
 network = ErdosRenyi
 *.numNodes = 50
+*.edgeFilePath = "${resultdir}/er_edges.txt"
 *.connectionProbability = 0.2
 *.faultInjector.faultProbability = 0
 

--- a/omnetpp/simulations/src/EdgeFileNetworkInitializer.cc
+++ b/omnetpp/simulations/src/EdgeFileNetworkInitializer.cc
@@ -1,0 +1,129 @@
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <omnetpp.h>
+
+using namespace omnetpp;
+
+namespace {
+
+static uint64_t edgeKey(int a, int b)
+{
+    int lo = std::min(a, b);
+    int hi = std::max(a, b);
+    return (static_cast<uint64_t>(static_cast<uint32_t>(lo)) << 32) |
+           static_cast<uint32_t>(hi);
+}
+
+static bool parseEdgeLine(const std::string& line, int& source, int& target)
+{
+    if (line.empty() || line[0] == '#') {
+        return false;
+    }
+    std::istringstream iss(line);
+    if (!(iss >> source)) {
+        return false;
+    }
+    if (iss.peek() == ',' || iss.peek() == ';') {
+        iss.get();
+    }
+    if (!(iss >> target)) {
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+class EdgeFileNetworkInitializer : public cSimpleModule
+{
+  protected:
+    virtual void initialize() override
+    {
+        const char *edgePathParam = par("edgeFilePath").stringValue();
+        std::string edgePath = edgePathParam ? edgePathParam : "";
+        if (edgePath.empty()) {
+            throw cRuntimeError("edgeFilePath is empty");
+        }
+
+        std::ifstream file(edgePath.c_str());
+        if (!file.is_open()) {
+            throw cRuntimeError("Cannot open edge file: %s", edgePath.c_str());
+        }
+
+        cModule *network = getParentModule();
+        if (!network) {
+            throw cRuntimeError("Initializer has no parent network module");
+        }
+        int numNodes = network->par("numNodes").intValue();
+        if (numNodes <= 0) {
+            throw cRuntimeError("numNodes must be positive (got %d)", numNodes);
+        }
+
+        std::unordered_set<uint64_t> seen;
+        std::string line;
+        int created = 0;
+        int parsed = 0;
+        int skippedOutOfBounds = 0;
+        int skippedDuplicates = 0;
+
+        while (std::getline(file, line)) {
+            int source = -1;
+            int target = -1;
+            if (!parseEdgeLine(line, source, target)) {
+                continue;
+            }
+            parsed++;
+
+            if (source == target ||
+                source < 0 || source >= numNodes ||
+                target < 0 || target >= numNodes) {
+                skippedOutOfBounds++;
+                continue;
+            }
+
+            uint64_t key = edgeKey(source, target);
+            if (!seen.insert(key).second) {
+                skippedDuplicates++;
+                continue;
+            }
+
+            cModule *srcMod = network->getSubmodule("node", source);
+            cModule *dstMod = network->getSubmodule("node", target);
+            if (!srcMod || !dstMod) {
+                throw cRuntimeError("Missing node module for edge (%d,%d)", source, target);
+            }
+
+            cGate *srcOut = srcMod->getOrCreateFirstUnconnectedGate("port$o", 0, false, true);
+            cGate *dstIn = dstMod->getOrCreateFirstUnconnectedGate("port$i", 0, false, true);
+            cGate *dstOut = dstMod->getOrCreateFirstUnconnectedGate("port$o", 0, false, true);
+            cGate *srcIn = srcMod->getOrCreateFirstUnconnectedGate("port$i", 0, false, true);
+
+            cDelayChannel *ch1 = cDelayChannel::create("channel");
+            ch1->setDelay(0.1);
+            srcOut->connectTo(dstIn, ch1);
+            ch1->callInitialize();
+
+            cDelayChannel *ch2 = cDelayChannel::create("channel");
+            ch2->setDelay(0.1);
+            dstOut->connectTo(srcIn, ch2);
+            ch2->callInitialize();
+
+            created++;
+        }
+
+        if (created == 0) {
+            throw cRuntimeError("No valid edges were created from edge file: %s", edgePath.c_str());
+        }
+
+        EV << "EdgeFileNetworkInitializer: created " << created
+           << " undirected edges (" << parsed << " parsed, "
+           << skippedDuplicates << " duplicates, "
+           << skippedOutOfBounds << " out-of-bounds) from "
+           << edgePath << endl;
+    }
+};
+
+Define_Module(EdgeFileNetworkInitializer);

--- a/omnetpp/simulations/src/TwitchNetworkInitializer.cc
+++ b/omnetpp/simulations/src/TwitchNetworkInitializer.cc
@@ -6,7 +6,7 @@
 
 using namespace omnetpp;
 
-class TwitchNetworkInitializer : public cModule
+class TwitchNetworkInitializer : public cSimpleModule
 {
   protected:
     virtual void initialize() override {

--- a/scripts/preprocess/generate_cbt.py
+++ b/scripts/preprocess/generate_cbt.py
@@ -1,21 +1,31 @@
 #!/usr/bin/env python3
 import argparse
-import math
 
-def generate_cbt(depth, output_file):
-    num_nodes = 2**(depth + 1) - 1
+
+def generate_cbt(num_nodes, output_file):
+    if num_nodes < 2:
+        raise ValueError(f"num_nodes must be >= 2 (got {num_nodes})")
     with open(output_file, 'w') as f:
-        f.write(f"# Complete Binary Tree with depth {depth} ({num_nodes} nodes)\n")
+        f.write(f"# Complete Binary Tree with {num_nodes} nodes\n")
         for i in range(1, num_nodes):
             parent = (i - 1) // 2
             f.write(f"{parent} {i}\n")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Generate Complete Binary Tree edge list')
-    parser.add_argument('--depth', type=int, required=True, help='Depth of the tree')
-    parser.add_argument('--output', type=str, default='cbt_edges.txt', 
-                       help='Output edge list file')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--depth', type=int, help='Depth of the tree')
+    group.add_argument('--nodes', type=int, help='Number of nodes')
+    parser.add_argument('--output', type=str, default='cbt_edges.txt',
+                        help='Output edge list file')
     args = parser.parse_args()
-    
-    generate_cbt(args.depth, args.output)
-    print(f"Generated Complete Binary Tree (depth={args.depth}) in {args.output}")
+
+    if args.depth is not None:
+        if args.depth < 0:
+            raise ValueError(f"depth must be >= 0 (got {args.depth})")
+        num_nodes = 2 ** (args.depth + 1) - 1
+    else:
+        num_nodes = int(args.nodes)
+
+    generate_cbt(num_nodes, args.output)
+    print(f"Generated Complete Binary Tree (n={num_nodes}) in {args.output}")

--- a/scripts/preprocess/generate_er.py
+++ b/scripts/preprocess/generate_er.py
@@ -2,7 +2,12 @@
 import argparse
 import random
 
+
 def generate_er(num_nodes, prob, output_file, seed=None):
+    if num_nodes < 2:
+        raise ValueError(f"num_nodes must be >= 2 (got {num_nodes})")
+    if prob < 0.0 or prob > 1.0:
+        raise ValueError(f"prob must be in [0,1] (got {prob})")
     if seed is not None:
         random.seed(seed)
     else:

--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -127,8 +127,28 @@ export OMNETPP_ROOT
 export OMNETPP_RNGSEEDSET="$SCM_RANDOM_SEED"
 
 # Generate topology files
-uv run python "$SCRIPT_DIR/preprocess/generate_cbt.py" --depth 5 --output "$RESULT_DIR/cbt_edges.txt"
-uv run python "$SCRIPT_DIR/preprocess/generate_er.py" --nodes 50 --prob 0.2 --seed "$SCM_RANDOM_SEED" --output "$RESULT_DIR/er_edges.txt"
+CBT_NODES=31
+ER_NODES=50
+ER_PROB=0.2
+if [[ "$MWE_MODE" -eq 1 ]]; then
+    CBT_NODES="${MWE_NUM_NODES:-1024}"
+elif [[ "$CLAIM_A_MODE" -eq 1 ]]; then
+    if [[ "$QUICK_MODE" -eq 1 ]]; then
+        CBT_NODES=63
+        ER_NODES=50
+    else
+        CBT_NODES=127
+        ER_NODES=100
+    fi
+elif [[ "$CLAIM_B_MODE" -eq 1 ]]; then
+    if [[ "$QUICK_MODE" -eq 1 ]]; then
+        CBT_NODES=63
+    else
+        CBT_NODES=127
+    fi
+fi
+uv run python "$SCRIPT_DIR/preprocess/generate_cbt.py" --nodes "$CBT_NODES" --output "$RESULT_DIR/cbt_edges.txt"
+uv run python "$SCRIPT_DIR/preprocess/generate_er.py" --nodes "$ER_NODES" --prob "$ER_PROB" --seed "$SCM_RANDOM_SEED" --output "$RESULT_DIR/er_edges.txt"
 
 # Run simulations
 SIM_DIR="$PROJECT_ROOT/omnetpp/simulations"
@@ -208,6 +228,9 @@ fi
 for config in "${configs[@]}"; do
     echo "Running $config..."
     config_result_dir="$sim_root/$config"
+    mkdir -p "$config_result_dir"
+    cp -f "$RESULT_DIR/cbt_edges.txt" "$config_result_dir/cbt_edges.txt"
+    cp -f "$RESULT_DIR/er_edges.txt" "$config_result_dir/er_edges.txt"
     if [[ "$MWE_MODE" -eq 1 ]]; then
         ./scm-simulations -u Cmdenv -c "$config" -n networks \
             --result-dir="$config_result_dir" \

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -19,6 +19,19 @@ class TestPreprocessScripts(unittest.TestCase):
             self.assertIn("0 1", lines)
             self.assertIn("0 2", lines)
 
+    def test_generate_cbt_nodes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "cbt_nodes.txt"
+            subprocess.run(
+                ["uv", "run", "python", "scripts/preprocess/generate_cbt.py", "--nodes", "10", "--output", str(out)],
+                check=True,
+            )
+            lines = out.read_text(encoding="utf-8").strip().splitlines()
+            self.assertTrue(lines[0].startswith("# Complete Binary Tree with 10 nodes"))
+            self.assertEqual(len(lines), 10)
+            self.assertIn("0 1", lines)
+            self.assertIn("4 9", lines)
+
     def test_generate_er_seeded_deterministic(self):
         with tempfile.TemporaryDirectory() as tmp:
             out1 = Path(tmp) / "er1.txt"
@@ -41,6 +54,27 @@ class TestPreprocessScripts(unittest.TestCase):
                 out1.read_text(encoding="utf-8"),
                 out2.read_text(encoding="utf-8"),
             )
+
+    def test_generate_er_invalid_probability_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "bad_er.txt"
+            proc = subprocess.run(
+                [
+                    "uv",
+                    "run",
+                    "python",
+                    "scripts/preprocess/generate_er.py",
+                    "--nodes",
+                    "12",
+                    "--prob",
+                    "1.2",
+                    "--output",
+                    str(out),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(proc.returncode, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
PR-C wires generated CBT/ER edge files into runtime topology construction and hardens validation/docs/CI around this path.

### Runtime wiring changes
- Added `EdgeFileNetworkInitializer` (`omnetpp/simulations/src/EdgeFileNetworkInitializer.cc`) and NED declaration (`networks/EdgeFileNetworkInitializer.ned`).
- `CompleteBinaryTree` and `ErdosRenyi` now use runtime initializers with `edgeFilePath` and no longer rely on in-NED implicit random wiring.
- `omnetpp.ini` baseline configs now set:
  - `*.edgeFilePath = "${resultdir}/cbt_edges.txt"` for CBT configs
  - `*.edgeFilePath = "${resultdir}/er_edges.txt"` for ER configs

### Orchestration + preprocessing hardening
- `run_experiments.sh` now generates edge files with node-count alignment per mode:
  - default quick/full CBT/ER
  - claim-a / claim-b quick/full
  - mwe via `MWE_NUM_NODES`
- Edge files are copied into each scenario output dir before run to satisfy `${resultdir}` resolution.
- `generate_cbt.py` now supports `--nodes` and validates inputs.
- `generate_er.py` now validates node/probability ranges fail-fast.

### Tests, docs, CI
- Extended `tests/test_preprocess.py` with:
  - `generate_cbt.py --nodes` coverage
  - invalid ER probability failure coverage
- Updated README/design/current-state docs to reflect active edge-file runtime wiring.
- Extended `.github/workflows/ci-smoke.yml` with claim-b fig5 smoke validation path.

## Validation
- `uv run python -m unittest tests/test_preprocess.py -v`
- `RESULT_DIR=/tmp/scm-prc-final SCM_RANDOM_SEED=1337 ./scripts/run_experiments.sh --skip-sim-build`
- `uv run python scripts/analysis/validate_outputs.py /tmp/scm-prc-final --require-columns scenario,value_mean,value_std,value_count,time_max --require-non-empty`
- `RESULT_DIR=/tmp/scm-prc-final-b SCM_RANDOM_SEED=1337 ./scripts/run_experiments.sh --claim-b --quick --skip-sim-build`
- `uv run python scripts/analysis/build_fig5_outputs.py /tmp/scm-prc-final-fig5 --result-root /tmp/scm-prc-final-b/claim-b`
- `uv run python scripts/analysis/validate_outputs.py /tmp/scm-prc-final-fig5 --require-columns topology,depth,algorithm,rounds_to_converge,correct_convergence --require-non-empty`

## Scope note
This closes the edge-file runtime wiring gap tracked in issue #33 and leaves only final full artifact rehearsal on `main`.
